### PR TITLE
Add codetab component

### DIFF
--- a/common/Mdx.re
+++ b/common/Mdx.re
@@ -139,8 +139,13 @@ module Components = {
         "href": string,
         "children": MdxChildren.t,
       }),
-    [@bs.as "CodeToggle"] [@bs.optional]
-    codeToggle: React.component({. "children": MdxChildren.t}),
+    [@bs.as "CodeTab"] [@bs.optional]
+    codeTab:
+      React.component({
+        .
+        "children": MdxChildren.t,
+        "labels": option(array(string)),
+      }),
     /* Common markdown elements */
     [@bs.optional]
     p: React.component(props),

--- a/components/CodeExample.re
+++ b/components/CodeExample.re
@@ -49,6 +49,7 @@ let make = (~code: string, ~lang="text") => {
 
 module Toggle = {
   type tab = {
+    label: option(string),
     lang: option(string),
     code: string,
   };
@@ -64,29 +65,31 @@ module Toggle = {
         Belt.Array.mapWithIndex(
           multiple,
           (i, tab) => {
+            // if there's no label, infer the label from the language
             let label =
-              switch (tab.lang) {
-              | Some(lang) => langShortname(lang)->Js.String2.toUpperCase
-              | None => string_of_int(i)
+              switch (tab.label) {
+              | Some(label) => label
+              | None =>
+                switch (tab.lang) {
+                | Some(lang) => langShortname(lang)->Js.String2.toUpperCase
+                | None => string_of_int(i)
+                }
               };
 
-            let className =
+            let activeClass =
               selected === i ? "text-fire-80" : "hover:cursor-pointer";
+
             let onClick = evt => {
               ReactEvent.Mouse.preventDefault(evt);
               setSelected(_ => i);
             };
             let key = label ++ "-" ++ string_of_int(i);
-            let spacer =
-              if (i > 0) {
-                <span className="mx-1"> "-"->s </span>;
-              } else {
-                React.null;
-              };
 
-            <span key>
-              spacer
-              <span className onClick> label->s </span>
+            <span
+              key
+              className={"inline-block p-2 last:border-r-0 border-r "  ++ activeClass}
+              onClick>
+              label->s
             </span>;
           },
         );
@@ -100,9 +103,9 @@ module Toggle = {
         ->Belt.Option.getWithDefault(React.null);
 
       <div
-        className="flex w-full flex-col rounded-none xs:rounded border-t border-b xs:border border-snow-dark bg-snow-light px-5 py-2 text-night-dark">
+        className="flex w-full flex-col rounded-none xs:rounded border-t border-b xs:border border-snow-dark bg-snow-light px-5 pb-2 text-night-dark">
         <div
-          className="flex self-end font-sans mb-4 text-sm font-bold text-night-light">
+          className="border-b border-l border-r flex self-end font-sans mb-6 md:mb-4 text-sm font-bold text-night-light">
           labels->ate
         </div>
         <div className="px-5 text-base pb-6 overflow-x-auto -mt-2">

--- a/components/Markdown.re
+++ b/components/Markdown.re
@@ -50,9 +50,15 @@ module Warn = {
   };
 };
 
-module CodeToggle = {
+module CodeTab = {
+  module Tab = {
+    [@react.component]
+    let make = () => {};
+  };
+
   [@react.component]
-  let make = (~children: Mdx.MdxChildren.t) => {
+  let make =
+      (~children: Mdx.MdxChildren.t, ~labels: array(string)=[||]) => {
     let mdxElements =
       switch (Mdx.MdxChildren.classify(children)) {
       | Array(mdxElements) => mdxElements
@@ -69,6 +75,7 @@ module CodeToggle = {
             mdxElement
             ->Mdx.MdxChildren.getMdxChildren
             ->Mdx.MdxChildren.classify;
+
           switch (child) {
           | Element(codeEl) =>
             switch (codeEl->Mdx.getMdxType) {
@@ -86,7 +93,8 @@ module CodeToggle = {
               let code =
                 Mdx.MdxChildren.flatten(codeEl)->Js.Array2.joinWith("");
 
-              let tab = {CodeExample.Toggle.lang, code};
+              let label = Belt.Array.get(labels, i);
+              let tab = {CodeExample.Toggle.lang, code, label};
               Js.Array2.push(acc, tab)->ignore;
 
             | _ => ()
@@ -567,7 +575,7 @@ let default =
     ~intro=Intro.make,
     ~warn=Warn.make,
     ~urlBox=UrlBox.make,
-    ~codeToggle=CodeToggle.make,
+    ~codeTab=CodeTab.make,
     ~p=P.make,
     ~li=Li.make,
     ~h1=H1.make,

--- a/pages/markdown-guide.mdx
+++ b/pages/markdown-guide.mdx
@@ -194,14 +194,14 @@ The default language is set to `text` and will not provide any syntax
 highlighting
 ```
 
-## Codeblocks with syntax toggles
+## CodeTabs
 
 For cases where you want to show a single codeblock with multiple syntaxes, use the `<CodeToggle>` component.
 Make sure to leave a newline between the `<CodeToggle>` JSX tags, otherwise codeblock children won't be recognized!
 
 **Example:**
 ~~~
-<CodeToggle>
+<CodeTab>
 
 ```res
 let a = "Some ReScript code"
@@ -211,17 +211,20 @@ let a = "Some ReScript code"
 var a = "Some JavaScript code";
 ```
 
-</CodeToggle>
+</CodeTab>
 ~~~
 
-<CodeToggle>
+<CodeTab labels={["ReScript", "JS Output"]}>
 
-```res
-let a = "Some ReScript code"
-```
+  ```res
+  let a = "Some ReScript code"
+  switch foo {
 
-```js
-var a = "Some JavaScript code";
-```
+  }
+  ```
 
-</CodeToggle>
+  ```js
+  var a = "Some JavaScript code";
+  ```
+
+</CodeTab>


### PR DESCRIPTION
Adds a codetab component for togglable syntax:

![image](https://user-images.githubusercontent.com/1121889/89656897-8ab0ec00-d8cc-11ea-82f4-86faf427c07a.png)
