### PR TITLE
Small docfix

### DIFF
--- a/pages/docs/react/latest/rendering-elements.mdx
+++ b/pages/docs/react/latest/rendering-elements.mdx
@@ -44,8 +44,8 @@ Here is a full example rendering our application in our `root` div:
 // Dom access can actually fail. ResScript
 // is really explicit about handling edge cases!
 switch(ReactDOM.querySelector("#root")){
-  | Some(root) => ReactDOM.render(<div> React.string("Hello Andrea") </div>, root)
-  | None => () // do nothing
+| Some(root) => ReactDOM.render(<div> {React.string("Hello Andrea")} </div>, root)
+| None => () // do nothing
 }
 ```
 ```js


### PR DESCRIPTION
The current parser seems to require braces `{` around the `React.string` call. Also updated the formatting to what is in my VS Code.