### PR TITLE
Syntax Lookup placeholder

### DIFF
--- a/misc_docs/syntax/language_placeholder.mdx
+++ b/misc_docs/syntax/language_placeholder.mdx
@@ -1,0 +1,57 @@
+---
+id: "placeholder"
+keywords: ["placeholder"]
+name: "_"
+summary: "This is a `placeholder`."
+category: "languageconstructs"
+---
+
+Placeholders may be used for [ignoring parts of values](/docs/manual/latest/pattern-matching-destructuring#ignore-part-of-a-value) (including serving as a catch-all in `switch` statements), and [specifying the position of an argument](/docs/manual/latest/pipe#pipe-placeholders).
+
+### Example: Ignoring values 
+
+<CodeTab labels={["ReScript", "JS Output"]}>
+
+```res
+switch person1 {
+| Teacher(_) => Js.log("Hi teacher")
+| Student(_) => Js.log("Hey student")
+}
+```
+
+```js
+if (person1.TAG === /* Teacher */ 0) {
+  console.log("Hi teacher");
+} else {
+  console.log("Hey student");
+}
+```
+
+</CodeTab>
+
+### Example: Specifying an argument position
+
+
+<CodeTab labels={["ReScript", "JS Output"]}>
+
+```res
+let greet = (greeting, name) => greeting ++ " " ++ name
+
+// Pipe the value "John" into the second argument of the greet() function.
+let greetJohn = "John"->greet("Hello", _)
+```
+
+```js
+function greet(greeting, name) {
+  return greeting + " " + name;
+}
+
+var greetJohn = "Hello John";
+```
+
+</CodeTab>
+
+### References
+
+* [Ignore part of a value](/docs/manual/latest/pattern-matching-destructuring#ignore-part-of-a-value)
+* [Pipe placeholders](/docs/manual/latest/pipe#pipe-placeholders)

--- a/src/SyntaxLookup.js
+++ b/src/SyntaxLookup.js
@@ -30,9 +30,11 @@ function toString(t) {
         return "Control Flow";
     case /* Operators */2 :
         return "Operators";
-    case /* SpecialValues */3 :
+    case /* LanguageConstructs */3 :
+        return "Language Constructs";
+    case /* SpecialValues */4 :
         return "Special Values";
-    case /* Other */4 :
+    case /* Other */5 :
         return "Other";
     
   }
@@ -44,12 +46,14 @@ function fromString(s) {
         return /* ControlFlow */1;
     case "decorators" :
         return /* Decorators */0;
+    case "languageconstructs" :
+        return /* LanguageConstructs */3;
     case "operators" :
         return /* Operators */2;
     case "specialvalues" :
-        return /* SpecialValues */3;
+        return /* SpecialValues */4;
     default:
-      return /* Other */4;
+      return /* Other */5;
   }
 }
 
@@ -243,9 +247,10 @@ function SyntaxLookup(Props) {
   var initial = Belt_Array.map([
         /* Decorators */0,
         /* Operators */2,
+        /* LanguageConstructs */3,
         /* ControlFlow */1,
-        /* SpecialValues */3,
-        /* Other */4
+        /* SpecialValues */4,
+        /* Other */5
       ], (function (cat) {
           return [
                   toString(cat),

--- a/src/SyntaxLookup.res
+++ b/src/SyntaxLookup.res
@@ -31,12 +31,13 @@ let requireSyntaxFile: string => MdxComp.t = %raw(`
 `)
 
 module Category = {
-  type t = Decorators | ControlFlow | Operators | SpecialValues | Other
+  type t = Decorators | ControlFlow | Operators | LanguageConstructs | SpecialValues | Other
 
   let toString = t =>
     switch t {
     | Decorators => "Decorators"
     | Operators => "Operators"
+    | LanguageConstructs => "Language Constructs"
     | SpecialValues => "Special Values"
     | ControlFlow => "Control Flow"
     | Other => "Other"
@@ -48,6 +49,7 @@ module Category = {
     | "controlflow" => ControlFlow
     | "specialvalues" => SpecialValues
     | "operators" => Operators
+    | "languageconstructs" => LanguageConstructs
     | _ => Other
     }
   }
@@ -241,6 +243,7 @@ let make = () => {
     let initial = [
       Decorators,
       Operators,
+      LanguageConstructs,
       ControlFlow,
       SpecialValues,
       Other,


### PR DESCRIPTION
Suggestion for #162

Draft content for the Syntax Lookup `placeholder`.

Notes:

* I wasn't sure how much content should be covered in the Syntax Lookup tool, so I've kept it minimal with links to primary documentation for now.
* I've added a new category "Language Constructs" for this. Let me know if this is not what you had in mind.

All feedback welcome.

Thanks.
