### PR TITLE
Escape array syntax appropriately in Markdown table

### DIFF
--- a/pages/docs/manual/v8.0.0/overview.mdx
+++ b/pages/docs/manual/v8.0.0/overview.mdx
@@ -78,7 +78,7 @@ canonical: "/docs/manual/latest/overview"
 
 | JavaScript            | Us                                 |
 | --------------------- | ---------------------------------- |
-| `[1, 2, 3]`           | `[|1, 2, 3|]`                      |
+| `[1, 2, 3]`           | <code>[&#124;1, 2, 3&#124;]</code> |
 | `myArray[1] = 10`     | Same                               |
 | `[1, "Bob", true]`    | `(1, "Bob", true)` \*              |
 


### PR DESCRIPTION
As the title says.