### PR TITLE
Update .github/workflows/pull-request.yml

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,11 +5,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: yarn install
+          node-version: 14.x
+      - run: yarn --frozen-lockfile
       - run: yarn run bs:build
       - run: yarn test


### PR DESCRIPTION
- v2 is more fast
- Node.js 14 is the latest LTS
- You should use `--frozen-lockfile` in CI (Read the yarn documentation for details)