### PR TITLE
fix tiny typo

### DIFF
--- a/pages/docs/react/latest/rendering-elements.mdx
+++ b/pages/docs/react/latest/rendering-elements.mdx
@@ -41,7 +41,7 @@ Here is a full example rendering our application in our `root` div:
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-// Dom access can actually fail. ResScript
+// Dom access can actually fail. ReScript
 // is really explicit about handling edge cases!
 switch(ReactDOM.querySelector("#root")){
 | Some(root) => ReactDOM.render(<div> {React.string("Hello Andrea")} </div>, root)


### PR DESCRIPTION
`ResScript` -> `ReScript`

😄 