### PR TITLE
Update latest doc to 9.0

### DIFF
--- a/compilers/package-lock.json
+++ b/compilers/package-lock.json
@@ -1,13 +1,36 @@
 {
   "name": "compilers",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "rescript-901": "npm:bs-platform@9.0.1"
+      }
+    },
+    "node_modules/rescript-901": {
+      "name": "bs-platform",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-9.0.1.tgz",
+      "integrity": "sha512-RxUrwxVBCx9AiiyFIthZwfPn+tAn9noRHCb9xJK4Uw2deGxIytqyoWDepMbH35v7EpxX0OhfXL5RrjHTaXersA==",
+      "deprecated": "use 9.0.2 for bug fix",
+      "hasInstallScript": true,
+      "bin": {
+        "bsb": "bsb",
+        "bsc": "bsc",
+        "bsrefmt": "bsrefmt",
+        "bstracing": "lib/bstracing"
+      }
+    }
+  },
   "dependencies": {
-    "rescript-820": {
-      "version": "npm:bs-platform@8.2.0",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-8.2.0.tgz",
-      "integrity": "sha512-quvmUac/ZxGDsT7L5+6RNXrLPvLHkWFownacaqlwVoyAm770bPyupTRU49ALPGk3HpjfD5eE+lpGdOSPtuwJiA=="
+    "rescript-901": {
+      "version": "npm:bs-platform@9.0.1",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-9.0.1.tgz",
+      "integrity": "sha512-RxUrwxVBCx9AiiyFIthZwfPn+tAn9noRHCb9xJK4Uw2deGxIytqyoWDepMbH35v7EpxX0OhfXL5RrjHTaXersA=="
     }
   }
 }

--- a/compilers/package.json
+++ b/compilers/package.json
@@ -5,6 +5,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "rescript-820": "npm:bs-platform@8.2.0"
+    "rescript-901": "npm:bs-platform@9.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^9.5.1",
-    "bs-platform": "8.4.2",
+    "bs-platform": "9.0.1",
     "cssnano": "^4.1.10",
     "postcss-cli": "^7.1.1",
     "reanalyze": "^2.5.0",

--- a/pages/docs/manual/latest/pattern-matching-destructuring.mdx
+++ b/pages/docs/manual/latest/pattern-matching-destructuring.mdx
@@ -433,7 +433,7 @@ if (typeof myStatus === "number" || myStatus.TAG) {
 
 Slightly more verbose, but a one-time writing effort. This helps when you add a new variant case e.g. `Quarantined` to the `status` type and need to update the places that pattern match on it. A top-level wildcard here would have accidentally and silently continued working, potentially causing bugs.
 
-### When Clause
+### If Clause
 
 Sometime, you want to check more than the shape of a value. You want to also run some arbitrary check on it. You might be tempted to write this:
 
@@ -469,7 +469,7 @@ if (person1.TAG) {
 ```res example
 switch person1 {
 | Teacher(_) => () // do nothing
-| Student({reportCard: {gpa}}) when gpa < 0.5 =>
+| Student({reportCard: {gpa}}) if gpa < 0.5 =>
   Js.log("What's happening")
 | Student(_) =>
   // fall-through, catch-all case

--- a/pages/docs/manual/latest/pattern-matching-destructuring.mdx
+++ b/pages/docs/manual/latest/pattern-matching-destructuring.mdx
@@ -488,6 +488,9 @@ if (person1.TAG) {
 
 </CodeTab>
 
+**Node**: Still `when` keyword is supported for backward compatibility, it will be removed near future.
+
+
 ### Match on Exceptions
 
 If the function throws an exception (covered later), you can also match on _that_, in addition to the function's normally returned values.
@@ -745,7 +748,7 @@ Here are some advices.
 
 Do not abuse the wildcard `_` too much. This prevents the compiler from giving you better exhaustiveness check, which would be especially important after a refactoring where you add a new case to a variant. Try only using `_` against infinite possibilities, e.g. string, int, etc.
 
-Use `when` clause sparingly.
+Use `if` clause sparingly.
 
 **Flatten your pattern-match whenever you can**. This is a real bug remover. Here's a series of examples, from worst to best:
 

--- a/pages/docs/manual/latest/polymorphic-variant.mdx
+++ b/pages/docs/manual/latest/polymorphic-variant.mdx
@@ -86,9 +86,9 @@ In rare cases (mostly for JS interop reasons), it's also possible to define "inv
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-type numbers = [#\"1" | #\"2"]
-let one = #\"1"
-let oneA = #\"1a"
+type numbers = [#"1" | #"2"]
+let one = #"1"
+let oneA = #"1a"
 ```
 
 ```js
@@ -298,7 +298,7 @@ let lowercased = #goodbye
 
 let err = #error("oops!")
 
-let num = #\"1"
+let num = #"1"
 ```
 
 ```js
@@ -328,7 +328,7 @@ For example, let's assume we want to bind to `Intl.NumberFormat` and want to mak
 type t
 
 @bs.val
-external make: ([#\"de-DE" | #\"en-GB" | #\"en-US" ]) => t = "Intl.NumberFormat"
+external make: ([#"de-DE" | #"en-GB" | #"en-US" ]) => t = "Intl.NumberFormat"
 ```
 
 We could later use our newly created bindings like this:
@@ -338,7 +338,7 @@ We could later use our newly created bindings like this:
 ```res
 // MyApp.res
 
-let intl = IntlNumberFormat.make(#\"de-DE")
+let intl = IntlNumberFormat.make(#"de-DE")
 ```
 
 ```js

--- a/pages/docs/manual/latest/polymorphic-variant.mdx
+++ b/pages/docs/manual/latest/polymorphic-variant.mdx
@@ -98,8 +98,6 @@ var oneA = "1a";
 
 </CodeTab>
 
-**Note:** The `\` character will be dropped in future ReScript versions for a cleaner look (`#"1"`).
-
 ### Constructor Arguments
 
 This is equivalent to what we've [already learned](variant#constructor-arguments) with common variants:

--- a/scripts/test-examples.js
+++ b/scripts/test-examples.js
@@ -9,7 +9,7 @@ let tempFileNameRegex = /_tempFile\.res/g
 // TODO: In the future we need to use the appropriate rescript version for each doc version variant
 //       see the package.json on how to define another rescript version
 let compilersDir = path.join(__dirname, "..", "compilers")
-let bsc = path.join(compilersDir, 'node_modules', 'rescript-820', process.platform, 'bsc.exe')
+let bsc = path.join(compilersDir, 'node_modules', 'rescript-901', process.platform, 'bsc.exe')
 
 const prepareCompilers = () => {
   if (fs.existsSync(bsc)) {
@@ -76,7 +76,8 @@ glob.sync(__dirname + '/../pages/docs/manual/latest/**/*.mdx').forEach((file) =>
   if (parsedResult != null) {
     fs.writeFileSync(tempFileName, parsedResult)
     try {
-      child_process.execFileSync(bsc, ['-i', tempFileName], {stdio: 'pipe'})
+      // -109 for suppressing `Toplevel expression is expected to have unit type.`
+      child_process.execFileSync(bsc, ['-i', tempFileName, '-w', '-109'], {stdio: 'pipe'})
     } catch (e) {
       process.stdout.write(postprocessOutput(file, e))
       success = false

--- a/src/common/App.js
+++ b/src/common/App.js
@@ -80,44 +80,39 @@ function make(props) {
             var match$1 = base[1];
             switch (match$1) {
               case "gentype" :
-                  var match$2 = url.version;
-                  if (typeof match$2 === "number") {
-                    if (match$2 === 0) {
-                      return React.createElement(GenTypeDocsLayout.make, {
-                                  frontmatter: component.frontmatter,
-                                  children: content
-                                });
-                    }
-                    exit = 1;
-                  } else {
-                    exit = 1;
+                  if (url.version === 0) {
+                    return React.createElement(GenTypeDocsLayout.make, {
+                                frontmatter: component.frontmatter,
+                                children: content
+                              });
                   }
+                  exit = 1;
                   break;
               case "manual" :
                   var pagepath = url.pagepath;
                   var version = url.version;
-                  var match$3 = Belt_Array.get(pagepath, 0);
+                  var match$2 = Belt_Array.get(pagepath, 0);
                   var exit$1 = 0;
-                  if (match$3 === "api") {
+                  if (match$2 === "api") {
                     if (typeof version === "number") {
                       if (version !== 0) {
                         return content;
                       }
-                      var match$4 = pagepath.length;
-                      var match$5 = Belt_Array.get(pagepath, 1);
+                      var match$3 = pagepath.length;
+                      var match$4 = Belt_Array.get(pagepath, 1);
                       var exit$2 = 0;
-                      if (match$4 === 1) {
+                      if (match$3 === 1) {
                         return React.createElement(ApiOverviewLayout.Docs.make, {
                                     children: content
                                   });
                       }
-                      if (match$4 !== 2) {
+                      if (match$3 !== 2) {
                         exit$2 = 3;
                       } else {
-                        if (match$5 === undefined) {
+                        if (match$4 === undefined) {
                           return null;
                         }
-                        switch (match$5) {
+                        switch (match$4) {
                           case "belt" :
                               return React.createElement(BeltDocsLayout.Prose.make, {
                                           children: content
@@ -131,10 +126,10 @@ function make(props) {
                         }
                       }
                       if (exit$2 === 3) {
-                        if (match$5 === undefined) {
+                        if (match$4 === undefined) {
                           return null;
                         }
-                        switch (match$5) {
+                        switch (match$4) {
                           case "belt" :
                               return React.createElement(BeltDocsLayout.Docs.make, {
                                           children: content
@@ -156,21 +151,21 @@ function make(props) {
                       if (version._0 !== "v8.0.0") {
                         return content;
                       }
-                      var match$6 = pagepath.length;
-                      var match$7 = Belt_Array.get(pagepath, 1);
+                      var match$5 = pagepath.length;
+                      var match$6 = Belt_Array.get(pagepath, 1);
                       var exit$3 = 0;
-                      if (match$6 === 1) {
+                      if (match$5 === 1) {
                         return React.createElement(ApiOverviewLayout8_0_0.Docs.make, {
                                     children: content
                                   });
                       }
-                      if (match$6 !== 2) {
+                      if (match$5 !== 2) {
                         exit$3 = 3;
                       } else {
-                        if (match$7 === undefined) {
+                        if (match$6 === undefined) {
                           return null;
                         }
-                        switch (match$7) {
+                        switch (match$6) {
                           case "belt" :
                               return React.createElement(BeltDocsLayout8_0_0.Prose.make, {
                                           children: content
@@ -184,10 +179,10 @@ function make(props) {
                         }
                       }
                       if (exit$3 === 3) {
-                        if (match$7 === undefined) {
+                        if (match$6 === undefined) {
                           return null;
                         }
-                        switch (match$7) {
+                        switch (match$6) {
                           case "belt" :
                               return React.createElement(BeltDocsLayout8_0_0.Docs.make, {
                                           children: content
@@ -230,31 +225,21 @@ function make(props) {
                   }
                   break;
               case "react" :
-                  var match$8 = url.version;
-                  if (typeof match$8 === "number") {
-                    if (match$8 === 0) {
-                      return React.createElement(ReactDocsLayout.make, {
-                                  frontmatter: component.frontmatter,
-                                  children: content
-                                });
-                    }
-                    exit = 1;
-                  } else {
-                    exit = 1;
+                  if (url.version === 0) {
+                    return React.createElement(ReactDocsLayout.make, {
+                                frontmatter: component.frontmatter,
+                                children: content
+                              });
                   }
+                  exit = 1;
                   break;
               case "reason-compiler" :
-                  var match$9 = url.version;
-                  if (typeof match$9 === "number") {
-                    if (match$9 === 0) {
-                      return React.createElement(ReasonCompilerDocsLayout.make, {
-                                  children: content
-                                });
-                    }
-                    exit = 1;
-                  } else {
-                    exit = 1;
+                  if (url.version === 0) {
+                    return React.createElement(ReasonCompilerDocsLayout.make, {
+                                children: content
+                              });
                   }
+                  exit = 1;
                   break;
               default:
                 exit = 1;
@@ -267,10 +252,10 @@ function make(props) {
     }
   }
   if (exit === 1) {
-    var match$10 = Belt_List.fromArray(base);
+    var match$7 = Belt_List.fromArray(base);
     var exit$4 = 0;
-    if (match$10) {
-      switch (match$10.hd) {
+    if (match$7) {
+      switch (match$7.hd) {
         case "blog" :
             return content;
         case "community" :
@@ -280,7 +265,7 @@ function make(props) {
                       });
         case "packages" :
         case "try" :
-            if (!match$10.tl) {
+            if (!match$7.tl) {
               return content;
             }
             exit$4 = 2;
@@ -295,14 +280,14 @@ function make(props) {
       var fm = DocFrontmatter.decode(component.frontmatter);
       var fm$1;
       fm$1 = fm.TAG === /* Ok */0 ? fm._0 : undefined;
-      var match$11 = url.base;
+      var match$8 = url.base;
       var title;
       var exit$5 = 0;
-      if (match$11.length !== 1) {
+      if (match$8.length !== 1) {
         exit$5 = 3;
       } else {
-        var match$12 = match$11[0];
-        if (match$12 === "docs") {
+        var match$9 = match$8[0];
+        if (match$9 === "docs") {
           title = "Overview | ReScript Documentation";
         } else {
           exit$5 = 3;

--- a/src/common/BlogFrontmatter.js
+++ b/src/common/BlogFrontmatter.js
@@ -76,7 +76,7 @@ var Badge = {
   toString: toString$1
 };
 
-var AuthorNotFound = Caml_exceptions.create("BlogFrontmatter.AuthorNotFound");
+var AuthorNotFound = /* @__PURE__ */Caml_exceptions.create("BlogFrontmatter.AuthorNotFound");
 
 function decodeAuthor(fieldName, authors, username) {
   var author = authors.find(function (a) {
@@ -87,7 +87,7 @@ function decodeAuthor(fieldName, authors, username) {
   }
   throw {
         RE_EXN_ID: AuthorNotFound,
-        _1: "Couldn\'t find author \"" + username + "\" in field " + fieldName,
+        _1: "Couldn't find author \"" + username + "\" in field " + fieldName,
         Error: new Error()
       };
 }

--- a/src/common/CompilerManagerHook.js
+++ b/src/common/CompilerManagerHook.js
@@ -500,7 +500,7 @@ function useCompilerManager(initialLangOpt, onAction, param) {
                   if (apiVersion) {
                     compResult = {
                       TAG: 2,
-                      _0: "Can\'t handle result of compiler API version \"" + apiVersion._0 + "\"",
+                      _0: "Can't handle result of compiler API version \"" + apiVersion._0 + "\"",
                       [Symbol.for("name")]: "UnexpectedError"
                     };
                   } else {

--- a/src/common/WarningFlagDescription.js
+++ b/src/common/WarningFlagDescription.js
@@ -354,7 +354,7 @@ function fuzzyLookup(str) {
   return Belt_Array.concat(letters, numbers);
 }
 
-var InvalidInput = Caml_exceptions.create("WarningFlagDescription.Parser.InvalidInput");
+var InvalidInput = /* @__PURE__ */Caml_exceptions.create("WarningFlagDescription.Parser.InvalidInput");
 
 function isModifier(str) {
   if (str === "+") {

--- a/src/layouts/ApiLayout.js
+++ b/src/layouts/ApiLayout.js
@@ -15,7 +15,7 @@ import * as VersionSelect from "../components/VersionSelect.js";
 var allApiVersions = [
   [
     "latest",
-    "v8.2.0"
+    "v9.0.1"
   ],
   [
     "v8.0.0",

--- a/src/layouts/ApiLayout.res
+++ b/src/layouts/ApiLayout.res
@@ -1,5 +1,5 @@
 // This is used for the version dropdown in the api layouts
-let allApiVersions = [("latest", "v8.2.0"), ("v8.0.0", "< v8.2.0")]
+let allApiVersions = [("latest", "v9.0.1"), ("v8.0.0", "< v8.2.0")]
 
 module Sidebar = SidebarLayout.Sidebar
 module Toc = SidebarLayout.Toc

--- a/src/layouts/ManualDocsLayout.js
+++ b/src/layouts/ManualDocsLayout.js
@@ -10,7 +10,7 @@ import * as Caml_option from "bs-platform/lib/es6/caml_option.js";
 var allManualVersions = [
   [
     "latest",
-    "v8.2.0"
+    "v9.0.1"
   ],
   [
     "v8.0.0",

--- a/src/layouts/ManualDocsLayout.res
+++ b/src/layouts/ManualDocsLayout.res
@@ -1,5 +1,5 @@
 // This is used for the version dropdown in the manual layouts
-let allManualVersions = [("latest", "v8.2.0"), ("v8.0.0", "< v8.2.0")]
+let allManualVersions = [("latest", "v9.0.1"), ("v8.0.0", "< v8.2.0")]
 
 module LatestLayout = DocsLayout.Make({
   // Structure defined by `scripts/extract-tocs.js`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,10 +2171,10 @@ bs-fetch@^0.3.1:
   resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.1.tgz#9c7d074b27e6bb2b9f2ec985964f32bcac49f79e"
   integrity sha512-MxwnuuXPldXnoCtlpeN5JNbbmb1tVgsqpLfVunvuMLAIQNyP0TqoImHiQRTz38PBSN8/iX+2yVlm+PFJfnHHiA==
 
-bs-platform@8.4.2:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-8.4.2.tgz#778dabd1dfb3bc95e0086c58dabae74e4ebdee8a"
-  integrity sha512-9q7S4/LLV/a68CweN382NJdCCr/lOSsJR3oQYnmPK98ChfO/AdiA3lYQkQTp6T+U0I5Z5RypUAUprNstwDtMDQ==
+bs-platform@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-9.0.1.tgz#069dae007aadb400963cec25c8349ea1f3f6cae0"
+  integrity sha512-RxUrwxVBCx9AiiyFIthZwfPn+tAn9noRHCb9xJK4Uw2deGxIytqyoWDepMbH35v7EpxX0OhfXL5RrjHTaXersA==
 
 buffer-from@^1.0.0, buffer-from@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
It's been almost 2 months since 9.0 rolled out; this is a good time to update the latest document to 9.0.

https://rescript-lang.org/blog/release-9-0

- [x] Cleaner Polyvariant Syntax
- [x] `when` -> `if` in pattern matching
