### PR TITLE
Remove unnecessary VSCode Tailwind configuration

### DIFF
--- a/pages/docs/react/latest/styling.mdx
+++ b/pages/docs/react/latest/styling.mdx
@@ -122,15 +122,6 @@ let make = (~active: bool) => {
 }
 ```
 
-When using the [Tailwind VSCode plugin](https://tailwindcss.com/docs/intellisense), make sure to include ReScript as a target language to get autocompletion:
-
-- Open your VSCode settings
-- Search for `Tailwind CSS: Include Languages`
-- Add a new item with following settings:
-  - Item: `rescript`
-  - Value: `html`
-
-
 > **Hint:** `rescript-lang.org` actually uses TailwindCSS under the hood! Check out our [codebase](https://github.com/rescript-association/rescript-lang.org) to get some more inspiration on usage patterns.
 
 


### PR DESCRIPTION
Manually adding ReScript as a language should no longer be necessary after tailwindlabs/tailwindcss-intellisense#222 merged.
