### PR TITLE
feat: Implement shortcut to focus search

### DIFF
--- a/src/components/DocSearch.js
+++ b/src/components/DocSearch.js
@@ -7,6 +7,11 @@ import * as Belt_Option from "bs-platform/lib/es6/belt_Option.js";
 import * as Caml_option from "bs-platform/lib/es6/caml_option.js";
 
 function DocSearch(Props) {
+  var inputRef = React.useRef(null);
+  var match = React.useState(function () {
+        return /* Inactive */1;
+      });
+  var setState = match[1];
   React.useEffect((function () {
           var init = window.docsearch;
           if (init !== undefined) {
@@ -16,13 +21,27 @@ function DocSearch(Props) {
                   inputSelector: "#docsearch"
                 });
           }
-          
+          var handleKeyDown = function (e) {
+            if (e.key === "/") {
+              Curry._1(setState, (function (param) {
+                      return /* Active */0;
+                    }));
+              setTimeout((function (param) {
+                      return Belt_Option.forEach(Caml_option.nullable_to_opt(inputRef.current), (function (prim) {
+                                    prim.focus();
+                                    
+                                  }));
+                    }), 0);
+              return ;
+            }
+            
+          };
+          window.addEventListener("keydown", handleKeyDown);
+          return (function (param) {
+                    window.addEventListener("keydown", handleKeyDown);
+                    
+                  });
         }), []);
-  var inputRef = React.useRef(null);
-  var match = React.useState(function () {
-        return /* Inactive */1;
-      });
-  var setState = match[1];
   var clearInput = function (param) {
     return Belt_Option.forEach(Caml_option.nullable_to_opt(inputRef.current), (function (el) {
                   el.value = "";

--- a/src/components/DocSearch.js
+++ b/src/components/DocSearch.js
@@ -21,27 +21,63 @@ function DocSearch(Props) {
                   inputSelector: "#docsearch"
                 });
           }
-          var handleKeyDown = function (e) {
-            if (e.key === "/") {
-              Curry._1(setState, (function (param) {
-                      return /* Active */0;
-                    }));
-              setTimeout((function (param) {
-                      return Belt_Option.forEach(Caml_option.nullable_to_opt(inputRef.current), (function (prim) {
-                                    prim.focus();
-                                    
-                                  }));
-                    }), 0);
-              return ;
+          
+        }), []);
+  React.useEffect((function () {
+          var isEditableTag = function (el) {
+            var match = el.tagName;
+            switch (match) {
+              case "INPUT" :
+              case "SELECT" :
+              case "TEXTAREA" :
+                  return true;
+              default:
+                return false;
             }
+          };
+          var focusSearch = function (e) {
+            var el = document.activeElement;
+            if (el !== undefined) {
+              var el$1 = Caml_option.valFromOption(el);
+              if (isEditableTag(el$1)) {
+                return ;
+              }
+              if (el$1.isContentEditable) {
+                return ;
+              }
+              
+            }
+            Curry._1(setState, (function (param) {
+                    return /* Active */0;
+                  }));
+            Belt_Option.forEach(Caml_option.nullable_to_opt(inputRef.current), (function (prim) {
+                    prim.focus();
+                    
+                  }));
+            e.preventDefault();
             
           };
-          window.addEventListener("keydown", handleKeyDown);
+          var handleGlobalKeyDown = function (e) {
+            var match = e.key;
+            switch (match) {
+              case "/" :
+                  return focusSearch(e);
+              case "k" :
+                  if (e.ctrlKey || e.metaKey) {
+                    return focusSearch(e);
+                  } else {
+                    return ;
+                  }
+              default:
+                return ;
+            }
+          };
+          window.addEventListener("keydown", handleGlobalKeyDown);
           return (function (param) {
-                    window.addEventListener("keydown", handleKeyDown);
+                    window.addEventListener("keydown", handleGlobalKeyDown);
                     
                   });
-        }), []);
+        }), [setState]);
   var clearInput = function (param) {
     return Belt_Option.forEach(Caml_option.nullable_to_opt(inputRef.current), (function (el) {
                   el.value = "";

--- a/src/components/DocSearch.res
+++ b/src/components/DocSearch.res
@@ -4,10 +4,13 @@ type options = {
   inputSelector: string,
 }
 
+@bs.val @bs.scope("document")
+external activeElement: option<Dom.element> = "activeElement"
+
 @bs.val @bs.scope("window")
 external docsearch: option<options => unit> = "docsearch"
 
-type keyboardEventLike = {key: string}
+type keyboardEventLike = {key: string, ctrlKey: bool, metaKey: bool}
 
 @bs.val @bs.scope("window")
 external addKeyboardEventListener: (string, keyboardEventLike => unit) => unit = "addEventListener"
@@ -16,10 +19,15 @@ external addKeyboardEventListener: (string, keyboardEventLike => unit) => unit =
 external removeKeyboardEventListener: (string, keyboardEventLike => unit) => unit =
   "addEventListener"
 
+@bs.send
+external keyboardEventPreventDefault: keyboardEventLike => unit = "preventDefault"
+
 type state =
   | Active
   | Inactive
 
+@bs.get external isContentEditable: Dom.element => bool = "isContentEditable"
+@bs.get external tagName: Dom.element => string = "tagName"
 @bs.send external focus: Dom.element => unit = "focus"
 @bs.send external blur: Dom.element => unit = "blur"
 @bs.set external value: (Dom.element, string) => unit = "value"
@@ -41,20 +49,40 @@ let make = () => {
     | None => ()
     }
 
-    let handleKeyDown = e => {
-      if e.key == "/" {
-        setState(_ => Active)
+    None
+  }, [])
 
-        Js.Global.setTimeout(() => {
-          // execture focus in the next tick to avoid setting / inside input
+  React.useEffect1(() => {
+    let isEditableTag = el =>
+      switch el->tagName {
+      | "TEXTAREA" | "SELECT" | "INPUT" => true
+      | _ => false
+      }
+
+    let focusSearch = e => {
+      switch activeElement {
+      | Some(el) when el->isEditableTag => ()
+      | Some(el) when el->isContentEditable => ()
+      | _ => {
+          setState(_ => Active)
           inputRef.current->Js.Nullable.toOption->Belt.Option.forEach(focus)
-        }, 0)->ignore
+
+          e->keyboardEventPreventDefault
+        }
       }
     }
 
-    addKeyboardEventListener("keydown", handleKeyDown)
-    Some(() => removeKeyboardEventListener("keydown", handleKeyDown))
-  }, [])
+    let handleGlobalKeyDown = e => {
+      switch e.key {
+      | "/" => focusSearch(e)
+      | "k" when e.ctrlKey || e.metaKey => focusSearch(e)
+      | _ => ()
+      }
+    }
+
+    addKeyboardEventListener("keydown", handleGlobalKeyDown)
+    Some(() => removeKeyboardEventListener("keydown", handleGlobalKeyDown))
+  }, [setState])
 
   let focusInput = () =>
     inputRef.current->Js.Nullable.toOption->Belt.Option.forEach(el => el->focus)


### PR DESCRIPTION
"/" to focus search is a widely popular shortcut for the quick focus of the search input. 

Examples:

1. Github (take a look on the top-left corner)
2. https://tailwindcss.com/
3. https://docs.cypress.io/
4. even https://reasonml.github.io/

There is another one – meta+k I can implement it as well if you want :) 