### PR TITLE
Don't wipe playground url on load; update on copy to clipboard

### DIFF
--- a/src/Playground.js
+++ b/src/Playground.js
@@ -1543,7 +1543,9 @@ function Playground$ControlPanel(Props) {
                 return acc + ("&" + (key + ("=" + value)));
               }
             }));
-      return window.location.origin + (router.route + querystring);
+      var url = window.location.origin + (router.route + querystring);
+      Next.Router.replace(router, url);
+      return url;
     };
     children = React.createElement(React.Fragment, undefined, React.createElement("div", {
               className: "mr-2"
@@ -1824,12 +1826,6 @@ function Playground$default(Props) {
       
     }
   }
-  React.useEffect((function () {
-          if (router.asPath !== "/try") {
-            Next.Router.replace(router, "/try");
-          }
-          
-        }), [router.route]);
   var match$2 = React.useState(function () {
         return 0;
       });

--- a/src/Playground.res
+++ b/src/Playground.res
@@ -1177,7 +1177,7 @@ module ControlPanel = {
     }
   }
 
-  @bs.val @bs.scope("window.location") external origin: string = "origin"
+  @bs.val @bs.scope(("window", "location")) external origin: string = "origin"
   @react.component
   let make = (
     ~actionIndicatorKey: string,
@@ -1217,7 +1217,9 @@ module ControlPanel = {
           }
         })
 
-        origin ++ (router.route ++ querystring)
+        let url = origin ++ (router.route ++ querystring)
+        Next.Router.replace(router, url)
+        url
       }
       <>
         <div className="mr-2">
@@ -1436,19 +1438,6 @@ let default = () => {
   | (None, Res)
   | (None, _) => initialResContent
   }
-
-  // We cleanup all the unwanted query attributes on load to make
-  // sure the url is not getting out of sync with the actual content
-  React.useEffect1(() => {
-    // Clean out the url after loading all query params
-    if router.asPath !== "/try" {
-      Next.Router.replace(router, "/try")
-    } else {
-      ()
-    }
-
-    None
-  }, [router.route])
 
   // We don't count to infinity. This value is only required to trigger
   // rerenders for specific components (ActivityIndicator)


### PR DESCRIPTION
Wiping the playground url turned out to be a less desirable UX than we
thought. Sometime tabs get backgrounded then ejected, so reloading those
with the default url gives us to the default snippet instead of the one
we loaded. Same for when we undo a closed tab.

I've removed that url wipe logic. I've also added the logic to update
the url on copy to clipboard, because why not. Maybe an incomplete UX,
but this beats updating the url every other second while typing, which
would be jarring
