### PR TITLE
Typo in syntax comparisation table name

### DIFF
--- a/pages/docs/manual/latest/overview.mdx
+++ b/pages/docs/manual/latest/overview.mdx
@@ -105,7 +105,7 @@ canonical: "/docs/manual/latest/overview"
   <thead>
     <tr>
       <th>JavaScript</th>
-      <th>Us    </th>
+      <th>ReScript  </th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
For uniformity with the other table names.