### PR TITLE
Upgrade docs to 8.3, 8.4 and then to 9.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ node_modules/
 .next/
 index_data/*.json
 
+pages/docs/manual/v8.0.0/
+
 yarn-error.log
 
 .bsb.lock

--- a/_blogposts/2020-12-07-release-8-4.mdx
+++ b/_blogposts/2020-12-07-release-8-4.mdx
@@ -55,30 +55,9 @@ dependent's command line flags for building binary artifacts. Such strategy bene
 
 ### Introducing `pinned-dependencies`
 
-To make `bsb -make-world` more practical, we also introduce a new concept called: `pinned-dependencies`.
-In general, packages are classified as three categories:
+To make `bsb -make-world` more practical for e.g. monorepo setups (`lerna`, `yarn workspaces`, etc.), we introduced a new concept called `pinned-dependencies`. A pinned dependency allows us to automatically rebuild packages that are pinned by a toplevel package, like your final webapp.
 
-- toplevel
-  - warnings reported
-  - warn-error respected
-  - build dev dependency
-  - run custom rules
-  - package-specs like ES6/CommonJS overrides all its dependencies
-- pinned dependencies
-  - warnings reported
-  - warn-error respected
-  - build dev dependency
-  - run custom rules
-- normal dependencies
-  - warnings, warn-error ignored
-  - ignore dev directories
-  - ignore custom generator rules
-
-Previously, we only had `toplevel` and `normal dependencies`, by introducing `pinned-dependencies`,
-such package will be built mostly like `toplevel` packages.
-
-The usage is quite simple, add `pinned-dependencies` in the toplevel package's `bsconfig.json`.
-Note such field only make sense in toplevel's configuration.
+Please refer to our [Monorepo Setup](/docs/manual/latest/build-monorepos) docs for more information on how to use `pinned-dependencies` with different monorepo setups.
 
 ### More robust handling of removal of staled output
 

--- a/_blogposts/2020-12-07-release-8-4.mdx
+++ b/_blogposts/2020-12-07-release-8-4.mdx
@@ -55,9 +55,9 @@ dependent's command line flags for building binary artifacts. Such strategy bene
 
 ### Introducing `pinned-dependencies`
 
-To make `bsb -make-world` more practical for e.g. monorepo setups (`lerna`, `yarn workspaces`, etc.), we introduced a new concept called `pinned-dependencies`. A pinned dependency allows us to automatically rebuild packages that are pinned by a toplevel package, like your final webapp.
+To make `bsb -make-world` more practical for e.g. multi-package setups (`lerna`, `yarn workspaces`, etc.), we introduced a new concept called `pinned-dependencies`. A pinned dependency allows you to automatically rebuild packages that are pinned by a toplevel package, like your final webapp.
 
-Please refer to our [Monorepo Setup](/docs/manual/latest/build-monorepos) docs for more information on how to use `pinned-dependencies` with different monorepo setups.
+Please refer to our [pinned dependencies](/docs/manual/latest/build-pinned-dependencies) docs for more details.
 
 ### More robust handling of removal of staled output
 

--- a/_blogposts/2021-02-09-release-9-0.mdx
+++ b/_blogposts/2021-02-09-release-9-0.mdx
@@ -35,48 +35,8 @@ Our compiler comes with a set of stdlib modules (such as `Belt`, `Pervasives`, e
 
 In previous versions, users couldn't ship their compiled JS code without defining a `package.json` dependency on `bs-platform`. Whenever a ReScript developer wanted to publish a package just for pure JS consumption / lean container deployment, they were required to use a bundler to bundle up their library / stdlib code, which made things way more complex and harder to understand.
 
-To fix this problem, we now publish our pre-compiled stdlib JS files as a separate npm package called [`@rescript/std`](https://www.npmjs.com/package/@rescript/std). Each new `bs-platform` release has a matching `@rescript/std` release for runtime compatibility.
 
-We also introduced a new configuration within our `bsconfig.json` file to tell the compiler to use our pre-compiled package instead:
-
-```json
-{
-  /* ... */
-  "external-stdlib" : "@rescript/std"
-}
-```
-
-With this configuration set, compiled JS code will now point to the defined `external-stdlib` path:
-
-<CodeTab labels={["ReScript", "JavaScript"]}>
-
-```res
-Belt.Array.forEach([1, 2, 3], (num) => Js.log(num))
-```
-
-```js
-// Note the import path starting with "@rescript/std"
-import * as Belt_Array from "@rescript/std/lib/es6/belt_Array.js";
-
-Belt_Array.forEach([
-      1,
-      2,
-      3
-    ], (function (num) {
-        console.log(num);
-        
-      }));
-```
-
-</CodeTab>
-
-The JavaScript output above was compiled with an `es6` target, but will also work with `commonjs`.
-
-**Important:** When using this option, you need to make sure that the version number of `bs-platform` and `@rescript/std` matches with the same version number in your `package.json` file, otherwise you'll eventually run into runtime problems due to mismatching stdlib behavior!
-
-To prevent unnecessary complications, only use this feature when...
-- You want to ship a library for JS / TS consumers without making them depend on `bs-platform`
-- You can't depend on `bs-platform` due to toolchain size (docker containers, low-storage deployment devices, etc)
+To fix this problem, we introduced an `external-stdlib` configuration that allows specifying a pre-compiled stdlib npm package (`@rescript/std`). More details on how to use that feature can be found in our [External Stdlib](/docs/manual/latest/build-external-stdlib) documentation.
 
 ### Less Bundle Bloat when Adding ReScript 
 

--- a/compilers/package-lock.json
+++ b/compilers/package-lock.json
@@ -8,6 +8,11 @@
       "version": "npm:bs-platform@8.2.0",
       "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-8.2.0.tgz",
       "integrity": "sha512-quvmUac/ZxGDsT7L5+6RNXrLPvLHkWFownacaqlwVoyAm770bPyupTRU49ALPGk3HpjfD5eE+lpGdOSPtuwJiA=="
+    },
+    "rescript-902": {
+      "version": "npm:bs-platform@9.0.2",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-9.0.2.tgz",
+      "integrity": "sha512-Ye9JqJ4Oa7mcjjoOVRYI8Uc2Cf8N7jQLWDcdUplY7996d/YErSR7WitmV7XnSwr4EvdrbwjEsg1NxNjUQv3ChA=="
     }
   }
 }

--- a/compilers/package.json
+++ b/compilers/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "rescript-902": "npm:bs-platform@9.0.2",
     "rescript-820": "npm:bs-platform@8.2.0"
   }
 }

--- a/data/blog_authors.json
+++ b/data/blog_authors.json
@@ -3,7 +3,7 @@
     "username": "hongbo",
     "fullname": "Hongbo Zhang",
     "role": "Compiler & Build System",
-    "img_url": "https://pbs.twimg.com/profile_images/3157941111/cf58e90adce60b796f589b2ae5a0394a_400x400.jpeg",
+    "img_url": "https://pbs.twimg.com/profile_images/1369548222314598400/E2y46vrB_400x400.jpg",
     "twitter": "bobzhang1988"
   },
   {

--- a/data/build-schema.json
+++ b/data/build-schema.json
@@ -154,8 +154,7 @@
                    
                         "type": {
                             "enum": [
-                                "dev",
-                                "lib"
+                                "dev"
                             ]
                         },
                         "files": {
@@ -481,23 +480,16 @@
             "type": "boolean",
             "description": "(Experimental) whether to use the OCaml standard library. Default: true"
         },
+        "external-stdlib" : {
+            "type" : "string",
+            "description": "Use the external stdlib library instead of the one shipped with the compiler package"
+        },
         "bs-external-includes": {
             "type": "array",
             "items": {
                 "type": "string"
             },
             "description": "(Not needed usually) external include directories, which will be applied `-I` to all compilation units"
-        },
-        "refmt": {
-            "$ref": "#/definitions/refmt-specs",
-            "description": "Reason syntax configuration"
-        },
-        "refmt-flags": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "description": "(Not needed usually) arguments to pass to `refmt` above. Default: `[\"--print\", \"binary\"]`."
         },
         "suffix" : {
             "$ref" : "#/definitions/suffix-spec"

--- a/data/sidebar_manual_latest.json
+++ b/data/sidebar_manual_latest.json
@@ -54,7 +54,7 @@
     "build-configuration",
     "build-configuration-schema",
     "build-external-stdlib",
-    "build-monorepos",
+    "build-pinned-dependencies",
     "interop-with-js-build-systems",
     "build-performance"
   ],

--- a/data/sidebar_manual_latest.json
+++ b/data/sidebar_manual_latest.json
@@ -53,6 +53,7 @@
     "build-overview",
     "build-configuration",
     "build-configuration-schema",
+    "build-monorepos",
     "interop-with-js-build-systems",
     "build-performance"
   ],

--- a/data/sidebar_manual_latest.json
+++ b/data/sidebar_manual_latest.json
@@ -53,6 +53,7 @@
     "build-overview",
     "build-configuration",
     "build-configuration-schema",
+    "build-external-stdlib",
     "build-monorepos",
     "interop-with-js-build-systems",
     "build-performance"

--- a/pages/docs/manual/latest/api/js/array-2.mdx
+++ b/pages/docs/manual/latest/api/js/array-2.mdx
@@ -47,7 +47,7 @@ A type used to describe JavaScript objects that are like an array or are iterabl
 ## from
 
 ```res sig
-let from: array_like<'a> => array<'b>
+let from: array_like<'a> => array<'a>
 ```
 
 Creates a shallow copy of an array from an array-like object. See [`Array.from`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from) on MDN.

--- a/pages/docs/manual/latest/api/js/array.mdx
+++ b/pages/docs/manual/latest/api/js/array.mdx
@@ -48,7 +48,7 @@ A type used to describe JavaScript objects that are like an array or are iterabl
 ## from
 
 ```res sig
-let from: array_like<'a> => array<'b>
+let from: array_like<'a> => array<'a>
 ```
 
 Creates a shallow copy of an array from an array-like object. See [`Array.from`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from) on MDN.

--- a/pages/docs/manual/latest/attribute.mdx
+++ b/pages/docs/manual/latest/attribute.mdx
@@ -11,7 +11,7 @@ Like many other languages, ReScript allows annotating a piece of code to express
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-@bs.inline
+@inline
 let mode = "dev"
 
 let mode2 = mode
@@ -22,7 +22,7 @@ var mode2 = "dev";
 
 </CodeTab>
 
-The `@bs.inline` annotation tells `mode`'s value to be inlined into its usage sites (see output). We call such annotation "attribute" (or "decorator" in JavaScript).
+The `@inline` annotation tells `mode`'s value to be inlined into its usage sites (see output). We call such annotation "attribute" (or "decorator" in JavaScript).
 
 An attribute starts with `@` and goes before the item it annotates. In the above example, it's hooked onto the let binding.
 
@@ -39,11 +39,11 @@ You can put an attribute almost anywhere. You can even add extra data to them by
 @unboxed
 type a = Name(string)
 
-@bs.val external message: string = "message"
+@val external message: string = "message"
 
 type student = {
   age: int,
-  @bs.as("aria-label") ariaLabel: string,
+  @as("aria-label") ariaLabel: string,
 }
 
 @deprecated
@@ -59,8 +59,8 @@ let customTriple = foo => foo * 3
 
 1. `@@warning("-27")` is a standalone attribute that annotates the entire file. Those attributes start with `@@`. Here, it carries the data `"-27"`.
 2. `@unboxed` annotates the type definition.
-3. `@bs.val` annotates the `external` statement.
-4. `@bs.as("aria-label")` annotates the `ariaLabel` record field.
+3. `@val` annotates the `external` statement.
+4. `@as("aria-label")` annotates the `ariaLabel` record field.
 5. `@deprecated` annotates the `customDouble` expression. This shows a warning while compiling telling consumers to not rely on this method long-term.
 6. `@deprecated("Use SomeOther.customTriple instead")` annotates the `customTriple` expression with a string to describe the reason for deprecation.
 

--- a/pages/docs/manual/latest/bind-to-global-js-values.mdx
+++ b/pages/docs/manual/latest/bind-to-global-js-values.mdx
@@ -13,8 +13,8 @@ Some JS values, like `setTimeout`, live in the global scope. You can bind to the
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.val external setTimeout: (unit => unit, int) => float = "setTimeout"
-@bs.val external clearTimeout: float => unit = "clearTimeout"
+@val external setTimeout: (unit => unit, int) => float = "setTimeout"
+@val external clearTimeout: float => unit = "clearTimeout"
 ```
 ```js
 // Empty output
@@ -40,8 +40,8 @@ We're in a language with a great type system now! Let's leverage a popular featu
 
 ```res example
 type timerId
-@bs.val external setTimeout: (unit => unit, int) => timerId = "setTimeout"
-@bs.val external clearTimeout: timerId => unit = "clearTimeout"
+@val external setTimeout: (unit => unit, int) => timerId = "setTimeout"
+@val external clearTimeout: timerId => unit = "clearTimeout"
 
 let id = setTimeout(() => Js.log("hello"), 100)
 clearTimeout(id)
@@ -62,12 +62,12 @@ Since `external`s are inlined, we end up with JS output as readable as hand-writ
 
 ## Global Modules
 
-If you want to bind to a value inside a global module, e.g. `Math.random`, attach a `bs.scope` to your `bs.val` external:
+If you want to bind to a value inside a global module, e.g. `Math.random`, attach a `scope` to your `val` external:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.scope("Math") @bs.val external random: unit => float = "random"
+@scope("Math") @val external random: unit => float = "random"
 let someNumber = random()
 ```
 ```js
@@ -76,12 +76,12 @@ var someNumber = Math.random();
 
 </CodeTab>
 
-you can bind to an arbitrarily deep object by passing a tuple to `bs.scope`:
+you can bind to an arbitrarily deep object by passing a tuple to `scope`:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.val @bs.scope(("window", "location", "ancestorOrigins"))
+@val @scope(("window", "location", "ancestorOrigins"))
 external length: int = "length"
 ```
 ```js

--- a/pages/docs/manual/latest/bind-to-js-function.mdx
+++ b/pages/docs/manual/latest/bind-to-js-function.mdx
@@ -12,7 +12,7 @@ Binding a JS function is like binding any other value:
 
 ```res example
 // Import nodejs' path.dirname
-@bs.module("path") external dirname: string => string = "dirname"
+@module("path") external dirname: string => string = "dirname"
 let root = dirname("/User/github") // returns "User"
 ```
 ```js
@@ -43,7 +43,7 @@ It'd be nice if on ReScript's side, we can bind & call `draw` while labeling thi
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.module("MyGame")
+@module("MyGame")
 external draw: (~x: int, ~y: int, ~border: bool=?, unit) => unit = "draw"
 
 draw(~x=10, ~y=20, ~border=true, ())
@@ -67,7 +67,7 @@ Note that you can freely reorder the labels on the ReScript side; they'll always
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.module("MyGame")
+@module("MyGame")
 external draw: (~x: int, ~y: int, ~border: bool=?, unit) => unit = "draw"
 
 draw(~x=10, ~y=20, ())
@@ -84,14 +84,14 @@ MyGame.draw(10, 20, undefined);
 
 ## Object Method
 
-Functions attached to a JS objects (other than JS modules) require a special way of binding to them, using `bs.send`:
+Functions attached to a JS objects (other than JS modules) require a special way of binding to them, using `send`:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
 type document // abstract type for a document object
-@bs.send external getElementById: (document, string) => Dom.element = "getElementById"
-@bs.val external doc: document = "document"
+@send external getElementById: (document, string) => Dom.element = "getElementById"
+@val external doc: document = "document"
 
 let el = getElementById(doc, "myId")
 ```
@@ -101,7 +101,7 @@ var el = document.getElementById("myId");
 
 </CodeTab>
 
-In a `bs.send`, the object is always the first argument. Actual arguments of the method follow (this is a bit what modern OOP objects are really).
+In a `send`, the object is always the first argument. Actual arguments of the method follow (this is a bit what modern OOP objects are really).
 
 ### Chaining
 
@@ -109,12 +109,12 @@ Ever used `foo().bar().baz()` chaining ("fluent api") in JS OOP? We can model th
 
 ## Variadic Function Arguments
 
-You might have JS functions that take an arbitrary amount of arguments. ReScript supports modeling those, under the condition that the arbitrary arguments part is homogenous (aka of the same type). If so, add `bs.variadic` to your `external`.
+You might have JS functions that take an arbitrary amount of arguments. ReScript supports modeling those, under the condition that the arbitrary arguments part is homogenous (aka of the same type). If so, add `variadic` to your `external`.
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.module("path") @bs.variadic
+@module("path") @variadic
 external join: array<string> => string = "join"
 
 let v = join(["a", "b"])
@@ -126,7 +126,7 @@ var v = Path.join("a", "b");
 
 </CodeTab>
 
-`bs.module` will be explained in [Import from/Export to JS](import-from-export-to-js.md).
+`module` will be explained in [Import from/Export to JS](import-from-export-to-js.md).
 
 ## Modeling Polymorphic Function
 
@@ -139,9 +139,9 @@ If you can exhaustively enumerate the many forms an overloaded JS function can t
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.module("MyGame") external drawCat: unit => unit = "draw"
-@bs.module("MyGame") external drawDog: (~giveName: string) => unit = "draw"
-@bs.module("MyGame") external draw: (string, ~useRandomAnimal: bool) => unit = "draw"
+@module("MyGame") external drawCat: unit => unit = "draw"
+@module("MyGame") external drawDog: (~giveName: string) => unit = "draw"
+@module("MyGame") external draw: (string, ~useRandomAnimal: bool) => unit = "draw"
 ```
 ```js
 // Empty output
@@ -151,7 +151,7 @@ If you can exhaustively enumerate the many forms an overloaded JS function can t
 
 Note how all three externals bind to the same JS function, `draw`.
 
-### Trick 2: Polymorphic Variant + `bs.unwrap`
+### Trick 2: Polymorphic Variant + `unwrap`
 
 If you have the irresistible urge of saying "if only this JS function argument was a variant instead of informally being either `string` or `int`", then good news: we do provide such `external` features through annotating a parameter as a polymorphic variant! Assuming you have the following JS function you'd like to bind to:
 
@@ -172,10 +172,10 @@ Here, `padding` is really conceptually a variant. Let's model it as such.
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.val
+@val
 external padLeft: (
   string,
-  @bs.unwrap [
+  @unwrap [
     | #Str(string)
     | #Int(int)
   ])
@@ -190,21 +190,21 @@ padLeft("Hello World", "Message from ReScript: ");
 
 </CodeTab>
 
-Obviously, the JS side couldn't have an argument that's a polymorphic variant! But here, we're just piggy backing on poly variants' type checking and syntax. The secret is the `@bs.unwrap` annotation on the type. It strips the variant constructors and compile to just the payload's value. See the output.
+Obviously, the JS side couldn't have an argument that's a polymorphic variant! But here, we're just piggy backing on poly variants' type checking and syntax. The secret is the `@unwrap` annotation on the type. It strips the variant constructors and compile to just the payload's value. See the output.
 
 ## Constrain Arguments Better
 
-Consider the Node `fs.readFileSync`'s second argument. It can take a string, but really only a defined set: `"ascii"`, `"utf8"`, etc. You can still bind it as a string, but we can use poly variants + `bs.string` to ensure that our usage's more correct:
+Consider the Node `fs.readFileSync`'s second argument. It can take a string, but really only a defined set: `"ascii"`, `"utf8"`, etc. You can still bind it as a string, but we can use poly variants + `string` to ensure that our usage's more correct:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.module("fs")
+@module("fs")
 external readFileSync: (
   ~name: string,
-  @bs.string [
+  @string [
     | #utf8
-    | @bs.as("ascii") #useAscii
+    | @as("ascii") #useAscii
   ],
 ) => string = "readFileSync"
 
@@ -217,21 +217,21 @@ Fs.readFileSync("xx.txt", "ascii");
 
 </CodeTab>
 
-- Attaching `@bs.string` to the whole poly variant type makes its constructor compile to a string of the same name.
-- Attaching a `@bs.as("bla")` to a constructor lets you customize the final string.
+- Attaching `@string` to the whole poly variant type makes its constructor compile to a string of the same name.
+- Attaching a `@as("bla")` to a constructor lets you customize the final string.
 
 And now, passing something like `"myOwnUnicode"` or other variant constructor names to `readFileSync` would correctly error.
 
-Aside from string, you can also compile an argument to an int, using `bs.int` instead of `bs.string` in a similar way:
+Aside from string, you can also compile an argument to an int, using `int` instead of `string` in a similar way:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.val
+@val
 external testIntType: (
-  @bs.int [
+  @int [
     | #onClosed
-    | @bs.as(20) #onOpen
+    | @as(20) #onOpen
     | #inBinary
   ])
   => int = "testIntType"
@@ -254,10 +254,10 @@ One last trick with polymorphic variants:
 ```res example
 type readline
 
-@bs.send
+@send
 external on: (
     readline,
-    @bs.string [
+    @string [
       | #close(unit => unit)
       | #line(string => unit)
     ]
@@ -290,9 +290,9 @@ Sometimes it's convenient to bind to a function using an `external`, while passi
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.val
+@val
 external processOnExit: (
-  @bs.as("exit") _,
+  @as("exit") _,
   int => unit
 ) => unit = "process.on"
 
@@ -308,7 +308,7 @@ process.on("exit", function (exitCode) {
 
 </CodeTab>
 
-The `@bs.as("exit")` and the placeholder `_` argument together indicates that you want the first argument to compile to the string `"exit"`. You can also use any JSON literal with `bs.as`: `` @bs.as(json`true`) ``, `` @bs.as(json`{"name": "John"}`) ``, etc.
+The `@as("exit")` and the placeholder `_` argument together indicates that you want the first argument to compile to the string `"exit"`. You can also use any JSON literal with `as`: `` @as(json`true`) ``, `` @as(json`{"name": "John"}`) ``, etc.
 
 ## Curry & Uncurry
 
@@ -338,7 +338,7 @@ Unfortunately, due to JS not having currying because of the aforementioned reaso
 
 ReScript tries to do #1 as much as it can. Even when it bails and uses #2's currying mechanism, it's usually harmless.
 
-**However**, if you encounter #3, heuristics are not good enough: you need a guaranteed way of fully applying a function, without intermediate currying steps. We provide such guarantee through the use of the `@bs` "uncurrying" annotation on a function declaration & call site.
+**However**, if you encounter #3, heuristics are not good enough: you need a guaranteed way of fully applying a function, without intermediate currying steps. We provide such guarantee through the use of the ["uncurrying" syntax](./function#uncurried-function) on a function declaration & call site.
 
 ### Solution: Use Guaranteed Uncurrying
 
@@ -348,7 +348,7 @@ ReScript tries to do #1 as much as it can. Even when it bails and uses #2's curr
 
 ```res example
 type timerId
-@bs.val external setTimeout: ((. unit) => unit, int) => timerId = "setTimeout"
+@val external setTimeout: ((. unit) => unit, int) => timerId = "setTimeout"
 
 let id = setTimeout((.) => Js.log("hello"), 1000)
 ```
@@ -370,12 +370,12 @@ The above solution is safe, guaranteed, and performant, but sometimes visually a
 
 <!-- TODO: is this up-to-date info? -->
 
-Then try `@bs.uncurry`:
+Then try `@uncurry`:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.send external map: (array<'a>, @bs.uncurry ('a => 'b)) => array<'b> = "map"
+@send external map: (array<'a>, @uncurry ('a => 'b)) => array<'b> = "map"
 map([1, 2, 3], x => x + 1)
 ```
 ```js
@@ -384,7 +384,7 @@ map([1, 2, 3], x => x + 1)
 
 </CodeTab>
 
-In general, `bs.uncurry` is recommended; the compiler will do lots of optimizations to resolve the currying to uncurrying at compile time. However, there are some cases the compiler can't optimize it. In these cases, it will be converted to a runtime check.
+In general, `uncurry` is recommended; the compiler will do lots of optimizations to resolve the currying to uncurrying at compile time. However, there are some cases the compiler can't optimize it. In these cases, it will be converted to a runtime check.
 
 ## Modeling `this`-based Callbacks
 
@@ -396,16 +396,16 @@ x.onload = function(v) {
 }
 ```
 
-Here, `this` would point to `x` (actually, it depends on how `onload` is called, but we digress). It's not correct to declare `x.onload` of type `(. unit) -> unit`. Instead, we introduced a special attribute, `bs.this`, which allows us to type `x` as so:
+Here, `this` would point to `x` (actually, it depends on how `onload` is called, but we digress). It's not correct to declare `x.onload` of type `(. unit) -> unit`. Instead, we introduced a special attribute, `this`, which allows us to type `x` as so:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
 type x
-@bs.val external x: x = "x"
-@bs.set external setOnload: (x, @bs.this ((x, int) => unit)) => unit = "onload"
-@bs.get external resp: x => int = "response"
-setOnload(x, @bs.this ((o, v) => Js.log(resp(o) + v)))
+@val external x: x = "x"
+@set external setOnload: (x, @this ((x, int) => unit)) => unit = "onload"
+@get external resp: x => int = "response"
+setOnload(x, @this ((o, v) => Js.log(resp(o) + v)))
 ```
 ```js
 x.onload = function (v) {
@@ -416,11 +416,11 @@ x.onload = function (v) {
 
 </CodeTab>
 
-`bs.this` has its first parameter is reserved for `this` and for arity of 0, there is no need for a redundant `unit` type.
+`this` has its first parameter is reserved for `this` and for arity of 0, there is no need for a redundant `unit` type.
 
 ## Function Nullable Return Value Wrapping
 
-For JS functions that return a value that can also be `undefined` or `null`, we provide `@bs.return(...)`. To automatically convert that value to an `option` type (recall that ReScript `option` type's `None` value only compiles to `undefined` and not `null`).
+For JS functions that return a value that can also be `undefined` or `null`, we provide `@return(...)`. To automatically convert that value to an `option` type (recall that ReScript `option` type's `None` value only compiles to `undefined` and not `null`).
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
@@ -428,7 +428,7 @@ For JS functions that return a value that can also be `undefined` or `null`, we 
 type element
 type dom
 
-@bs.send @bs.return(nullable)
+@send @return(nullable)
 external getElementById: (dom, string) => option<element> = "getElementById"
 
 let test = dom => {
@@ -454,7 +454,7 @@ function test(dom) {
 
 </CodeTab>
 
-`bs.return(nullable)` attribute will automatically convert `null` and `undefined` to `option` type.
+`return(nullable)` attribute will automatically convert `null` and `undefined` to `option` type.
 
 Currently 4 directives are supported: `null_to_opt`, `undefined_to_opt`, `nullable` and `identity`.
 

--- a/pages/docs/manual/latest/bind-to-js-object.mdx
+++ b/pages/docs/manual/latest/bind-to-js-object.mdx
@@ -15,7 +15,7 @@ JavaScript objects are a combination of several use-cases:
 
 ReScript cleanly separates the binding methods for JS object based on these 4 use-cases. This page documents the first three. Binding to JS module objects is described in the [Import from/Export to JS](import-from-export-to-js.md) section.
 
-<!-- TODO: mention bs.scope here too? -->
+<!-- TODO: mention scope here too? -->
 
 ## Bind to Record-like JS Objects
 
@@ -32,7 +32,7 @@ type person = {
   age: int,
 }
 
-@bs.module("MySchool") external john: person = "john"
+@module("MySchool") external john: person = "john"
 
 let johnName = john.name
 ```
@@ -44,7 +44,7 @@ var johnName = MySchool.john.name;
 
 </CodeTab>
 
-External is documented [here](external.md). `@bs.module` is documented [here](import-from-export-to-js.md).
+External is documented [here](external.md). `@module` is documented [here](import-from-export-to-js.md).
 
 ### Bind Using ReScript Object
 
@@ -59,7 +59,7 @@ type person = {
   "age": int,
 }
 
-@bs.module("MySchool") external john: person = "john"
+@module("MySchool") external john: person = "john"
 
 let johnName = john["name"]
 ```
@@ -71,31 +71,31 @@ var johnName = MySchool.john.name;
 
 </CodeTab>
 
-### Bind Using Special `@bs` Getters & Setters
+### Bind Using Special Getter and Setter Attributes
 
-Alternatively, you can use `bs.get` and `bs.set` to bind to individual fields of a JS object:
+Alternatively, you can use `get` and `set` to bind to individual fields of a JS object:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
 type textarea
-@bs.set external setName: (textarea, string) => unit = "name"
-@bs.get external getName: textarea => string = "name"
+@set external setName: (textarea, string) => unit = "name"
+@get external getName: textarea => string = "name"
 ```
 ```js
 ```
 
 </CodeTab>
 
-You can also use `bs.get_index` and `bs.set_index` to access a dynamic property or an index:
+You can also use `get_index` and `set_index` to access a dynamic property or an index:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
 type t
-@bs.new external create: int => t = "Int32Array"
-@bs.get_index external get: (t, int) => int = ""
-@bs.set_index external set: (t, int, int) => unit = ""
+@new external create: int => t = "Int32Array"
+@get_index external get: (t, int) => int = ""
+@set_index external set: (t, int, int) => unit = ""
 
 let i32arr = create(3)
 i32arr->set(0, 42)
@@ -120,13 +120,13 @@ Then it's not really an object, it's a hash map. Use [Js.Dict](api/js/dict), whi
 
 ## Bind to a JS Object That's a Class
 
-Use `bs.new` to emulate e.g. `new Date()`:
+Use `new` to emulate e.g. `new Date()`:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
 type t
-@bs.new external createDate: unit => t = "Date"
+@new external createDate: unit => t = "Date"
 
 let date = createDate()
 ```
@@ -136,13 +136,13 @@ var date = new Date();
 
 </CodeTab>
 
-You can chain `bs.new` and `bs.module` if the JS module you're importing is itself a class:
+You can chain `new` and `module` if the JS module you're importing is itself a class:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
 type t
-@bs.new @bs.module external book: unit => t = "Book"
+@new @module external book: unit => t = "Book"
 let myBook = book()
 ```
 ```js

--- a/pages/docs/manual/latest/build-configuration.mdx
+++ b/pages/docs/manual/latest/build-configuration.mdx
@@ -84,7 +84,7 @@ Note that only sources marked with `"type":"dev"` will be able to resolve module
 
 **Since 8.4**: List of pinned dependencies. A pinned dependency will always be rebuilt whenever you build a toplevel package (e.g. your main app) with `bsb -make-world`.
 
-This is useful for working on multiple independent ReScript packages simultaneously. More usage details can be found in our [monorepo setup](./build-monorepos) page.
+This is useful for working on multiple independent ReScript packages simultaneously. More usage details can be found in our dedicated [pinned dependencies](./build-pinned-dependencies) page.
 
 ## external-stdlib
 

--- a/pages/docs/manual/latest/build-configuration.mdx
+++ b/pages/docs/manual/latest/build-configuration.mdx
@@ -80,6 +80,18 @@ List of ReScript dependencies. Just like `package.json`'s dependencies, they'll 
 
 Note that only sources marked with `"type":"dev"` will be able to resolve modules from `bs-dev-dependencies`.
 
+## pinned-dependencies
+
+**Since 8.4**: List of pinned dependencies. A pinned dependency will always be rebuilt whenever you build a toplevel package (e.g. your main app) with `bsb -make-world`.
+
+This is useful for working on multiple independent ReScript packages simultaneously. More usage details can be found in our [monorepo setup](./build-monorepos) page.
+
+## external-stdlib
+
+**Since 9.0**: This setting allows depending on an externally built stdlib package (instead of a locally built stdlib runtime). Useful for shipping packages that are only consumed in JS or TS without any dependencies to the ReScript development toolchain.
+
+More details can be found on our [external stdlib](./build-external-stdlib) page.
+
 ## reason, refmt (old)
 
 `reason` config is enabled by default. To turn on JSX for [ReasonReact](https://reasonml.github.io/reason-react/), specify:
@@ -136,7 +148,7 @@ This configuration only applies to you, when you develop the project. When the p
 
 ## suffix
 
-Either `".js"` or `".bs.js"`. Strongly prefer the latter.
+Either `".js"`, `".mjs"`, `".cjs"` or `".bs.js"`. Currently prefer `bs.js` for now.
 
 ### Design Decisions
 
@@ -145,7 +157,7 @@ Generating JS files with the `.bs.js` suffix means that, on the JS side, you can
 - It's immediately clear that we're dealing with a generated JS file here.
 - It avoids clashes with a potential `theFile.js` file in the same folder.
 - It avoids the need of using a build system loader for ReScript files. This + in-source build means integrating a ReScript project into your pure JS codebase **basically doesn't touch anything in your build pipeline at all**.
-- The `.bs.js` suffix [lets bsb track JS artifacts much better](build-overview.md#tips-tricks).
+- [genType](/docs/gentype/latest/introduction) requires `bs.js` for compiled JS artifacts. If you are using `genType`, you need to use `bs.js` for now.
 
 ## warnings
 

--- a/pages/docs/manual/latest/build-external-stdlib.mdx
+++ b/pages/docs/manual/latest/build-external-stdlib.mdx
@@ -11,20 +11,26 @@ canonical: "/docs/manual/latest/build-external-stdlib"
 
 In a typical ReScript application, you'd ship a package with an npm dependency to `bs-platform` (`rescript`), which means downloading several tens of megabytes of executables.
 
-Whenever a ReScript developer wants to publish a package just for pure JS consumption / lean container deployment, they would be required to use a bundler to bundle up their library / stdlib code, which is not ideal. 
+Whenever you'd want to publish a package just for pure JS consumption / lean container deployment (package MB sizes), you'd be required to use a bundler to bundle up all the required stdlib runtime modules with your package source, which is not ideal. 
 
-To fix this problem, you can just depend on our pre-compiled stdlib JS files, published as a separate npm package called [`@rescript/std`](https://www.npmjs.com/package/@rescript/std). Each new ReScript release has a matching `@rescript/std` release for runtime compatibility.
+To fix this problem, you can configure your ReScript project to use our external stdlib package ([`@rescript/std`](https://www.npmjs.com/package/@rescript/std)) and make `bs-platform` a dev-only dependency.
+
+Every ReScript package release has a matching `@rescript/std` release for runtime compatibility.
+
+**Important:** To prevent unnecessary complications, only use this feature when...
+- You want to ship a library for JS / TS consumers without making them depend on `bs-platform`
+- You can't depend on `bs-platform` due to toolchain size (docker containers, low-storage deployment devices, etc)
 
 ## Configuration
 
-For example, let's assume we want to build a JS package that is built on ReScript 9.0. We'd first install our `@rescript/std` package:
+For example, let's assume we want to build a JS-only package that is built with ReScript 9.0. First, we would set up our dependencies like this:
 
 ```
 npm install bs-platform@9.0.0 --save-dev
 npm install @rescript/std@9.0.0 --save
 ```
 
-In your `bsconfig.json`, set up following configuration:
+In our `bsconfig.json`, we set up the following configuration:
 
 ```json
 {
@@ -33,7 +39,7 @@ In your `bsconfig.json`, set up following configuration:
 }
 ```
 
-With this configuration set, compiled JS code will now point to the defined external-stdlib path:
+Now our compiled JS code will point to the defined external-stdlib path (check the JS output of the following code snippet):
 
 <CodeTab labels={["ReScript", "JavaScript"]}>
 
@@ -42,7 +48,7 @@ Belt.Array.forEach([1, 2, 3], (num) => Js.log(num))
 ```
 
 ```js
-// Note the import path starting with "@rescript/std"
+// Note the import path starting with "@rescript/std".
 import * as Belt_Array from "@rescript/std/lib/es6/belt_Array.js";
 
 Belt_Array.forEach([
@@ -57,10 +63,5 @@ Belt_Array.forEach([
 
 </CodeTab>
 
-The JavaScript output above was compiled with an `es6` target, but will also work with `commonjs`.
+**Important:** When using the `external-stdlib` configuration, always make sure the version numbers of `bs-platform` and `@rescript/std` match in your `package.json` file. Otherwise you might run into runtime problems due to mismatching stdlib behavior.
 
-**Important:** When using this option, you need to make sure that the version number of `bs-platform` and `@rescript/std` matches with the same version number in your `package.json` file, otherwise you'll eventually run into runtime problems due to mismatching stdlib behavior!
-
-To prevent unnecessary complications, only use this feature when...
-- You want to ship a library for JS / TS consumers without making them depend on `bs-platform`
-- You can't depend on `bs-platform` due to toolchain size (docker containers, low-storage deployment devices, etc)

--- a/pages/docs/manual/latest/build-external-stdlib.mdx
+++ b/pages/docs/manual/latest/build-external-stdlib.mdx
@@ -1,0 +1,66 @@
+---
+title: "External Stdlib"
+metaTitle: "External Stdlib"
+description: "Configuring an external ReScript stdlib package"
+canonical: "/docs/manual/latest/build-external-stdlib"
+---
+
+# External Stdlib
+
+**Since 9.0**
+
+In a typical ReScript application, you'd ship a package with an npm dependency to `bs-platform` (`rescript`), which means downloading several tens of megabytes of executables.
+
+Whenever a ReScript developer wants to publish a package just for pure JS consumption / lean container deployment, they would be required to use a bundler to bundle up their library / stdlib code, which is not ideal. 
+
+To fix this problem, you can just depend on our pre-compiled stdlib JS files, published as a separate npm package called [`@rescript/std`](https://www.npmjs.com/package/@rescript/std). Each new ReScript release has a matching `@rescript/std` release for runtime compatibility.
+
+## Configuration
+
+For example, let's assume we want to build a JS package that is built on ReScript 9.0. We'd first install our `@rescript/std` package:
+
+```
+npm install bs-platform@9.0.0 --save-dev
+npm install @rescript/std@9.0.0 --save
+```
+
+In your `bsconfig.json`, set up following configuration:
+
+```json
+{
+  /* ... */
+  "external-stdlib" : "@rescript/std"
+}
+```
+
+With this configuration set, compiled JS code will now point to the defined external-stdlib path:
+
+<CodeTab labels={["ReScript", "JavaScript"]}>
+
+```res
+Belt.Array.forEach([1, 2, 3], (num) => Js.log(num))
+```
+
+```js
+// Note the import path starting with "@rescript/std"
+import * as Belt_Array from "@rescript/std/lib/es6/belt_Array.js";
+
+Belt_Array.forEach([
+      1,
+      2,
+      3
+    ], (function (num) {
+        console.log(num);
+        
+      }));
+```
+
+</CodeTab>
+
+The JavaScript output above was compiled with an `es6` target, but will also work with `commonjs`.
+
+**Important:** When using this option, you need to make sure that the version number of `bs-platform` and `@rescript/std` matches with the same version number in your `package.json` file, otherwise you'll eventually run into runtime problems due to mismatching stdlib behavior!
+
+To prevent unnecessary complications, only use this feature when...
+- You want to ship a library for JS / TS consumers without making them depend on `bs-platform`
+- You can't depend on `bs-platform` due to toolchain size (docker containers, low-storage deployment devices, etc)

--- a/pages/docs/manual/latest/build-monorepos.mdx
+++ b/pages/docs/manual/latest/build-monorepos.mdx
@@ -1,0 +1,107 @@
+---
+title: "Monorepo Setup"
+metaTitle: "Monorepo Setup"
+description: "Configuring ReScript in a monorepo like setup"
+canonical: "/docs/manual/latest/build-monorepos"
+---
+
+# Monorepo Setup
+
+**Since 8.4**
+
+We usually recommend using ReScript in a single-codebase style, where there is only one `bsconfig.json` file for the whole codebase. Many JavaScript libraries maintain multiple packages in one single codebase though, and use `yarn workspaces` to cross-link packages locally for development.
+
+This workflow is not straightforward for ReScript usage, so we need to explain some additional concepts to make this work. There are three different kinds of packages:
+
+- Toplevel (this is usually the final app you are building, which has dependencies to other packages)
+- Pinned dependencies (these are your local packages that should always rebuild when you build your toplevel, those should be listed in `bs-dependencies` and `pinned-dependencies`)
+- Normal dependencies (these are packages that are consumed from npm and listed via `bs-dependencies`)
+
+Whenever a package is being built (`bsb -make-world`), the build system will build the toplevel package with its pinned-dependencies. So any changes made in a pinned dependency will automatically be reflected in the final app.
+
+## Build System Package Rules
+
+The build system respects the following rules for each package type:
+
+**Toplevel**
+- Warnings reported
+- Warn-error respected
+- Builds dev dependencies
+- Builds pinned dependencies
+- Runs custom rules
+- Package-specs like ES6/CommonJS overrides all its dependencies
+
+**Pinned dependencies**
+- Warnings reported
+- Warn-error respected
+- Ignores pinned dependencies
+- Builds dev dependencies
+- Runs custom rules
+
+**Normal dependencies**
+- Warnings, warn-error ignored
+- Ignores dev directories
+- Ignores pinned dependencies
+- Ignores custom generator rules
+
+## Examples
+
+### Yarn workspaces
+
+Let's assume we have a codebase like this:
+
+```
+myproject/
+  app/
+   - src/App.res
+   - bsconfig.json
+  common/
+   - src/Header.res
+   - bsconfig.json
+  myplugin/
+   - src/MyPlugin.res
+   - bsconfig.json
+  package.json
+```
+
+Our `package.json` file within our codebase root would look like this:
+
+```json
+{
+  "name": "myproject",
+  "private": true,
+  "workspaces": {
+    "packages": [
+      "app",
+      "common",
+      "legacy"
+    ]
+  }
+}
+```
+
+
+Our `app` folder would be our toplevel package, consuming our `common` and `myplugin` packages as `pinned-dependencies`. The configuration for `app/bsconfig.json` looks like this:
+
+```json
+{
+  "name": "app",
+  "version": "1.0.0",
+  "sources": {
+    "dir" : "src",
+    "subdirs" : true
+  },
+  /* ... */
+  "bs-dependencies": [
+    "common",
+    "myplugin"
+  ],
+  "pinned-dependencies": ["common", "myplugin"],
+  /* ... */
+}
+```
+
+Now, whenever we are running `npx bsb -make-world` within our `app` package, the compiler would always rebuild any changes within its pinned dependencies as well.
+
+**Important:** ReScript will not rebuild any `pinned-dependencies` in watch mode! This is due to the complexity of file watching, so you'd need to set up your own file-watcher process that runs `bsb -make-world` on specific file changes. E.g. you could use [`watchman-make`](https://facebook.github.io/watchman/docs/watchman-make.html) to automatically run the build task when a file in `common` or `myplugin` has been changed.
+

--- a/pages/docs/manual/latest/build-overview.mdx
+++ b/pages/docs/manual/latest/build-overview.mdx
@@ -11,7 +11,11 @@ ReScript comes with a build system, bsb, that's meant to be fast, lean and used 
 
 The build description file is called `bsconfig.json`. Every ReScript project needs one.
 
-**To build a project**, run:
+## Build Project 
+
+Each build will create build artifacts from your project's source files.
+
+**To build a project (including its dependencies / pinned-dependencies)**, run:
 
 ```sh
 bsb -make-world
@@ -19,35 +23,25 @@ bsb -make-world
 
 Add `-w` to keep the built-in watcher running. Any new file change will be picked up and the build will re-run.
 
-**Note**: third-party libraries (in `node_modules`) aren't watched, as doing so may exceed the node.js watcher count limit. If you're doing quick and dirty modifications inside `node_modules`, you have to do `bsb -clean-world -make-world` to rebuild them.
+**Note**: third-party libraries (in `node_modules`, or via `pinned-dependencies`) aren't watched, as doing so may exceed the node.js watcher count limit.
 
-**Note 3**: If you are developing across multiple devices, you may find the `-ws` configuration useful in order to have live-reloading across the network. Possible configurations are:
-- `bsb -make-world -w -ws _` (default)
-- `bsb -make-world -w -ws 0.0.0.0:9999`
-- `bsb -make-world -w -ws 5000`
+**Note 2**: In case you want to set up a project in a JS-monorepo-esque approach (`yarn workspaces` / `lerna`) where changes in your sub packages should be noticed by the compiler (`bsb -make-world`), you will need to define pinned dependencies in your main project's `bsconfig.json`. More details [here](./build-pinned-dependencies).
 
-**To build only yourself**, use `bsb`.
+**To build only your project's files (without dependencies)**, run:
 
-`bsb -help` to see all the available options.
 
-## Artifacts Cleaning
+```sh
+bsb
+```
 
-If you ever get into a stable build for edge-case reasons, use:
+## Clean Project
+
+If you ever get into a stale build for edge-case reasons, use:
 
 ```sh
 bsb -clean-world
 ```
 
-Or `bsb -clean` to clean only your own artifacts.
+This will clean all your project's build artifacts, including those in your dependencies. Alternatively you can run `bsb -clean` to clean your project's build artifacts only.
 
-## Editor Support
-
-Bsb generates a `.merlin` file, used by various [editor plugins](editor-plugins.md) under the hood to power e.g. autocomplete, type hint, diagnosis, etc.
-
-### Tips & Tricks
-
-A typical problem with traditional build systems is that they're not resilient against the user moving/deleting source files. Most don't clean up the old artifacts correctly after such user action\*. Bsb is unfortunately no different, **unless** you turn on `"suffix": ".bs.js"` in `bsconfig.json`, in which case we can track which JS artifact belongs to which source file correctly, even against source file moving/deletion.
-
-## Design Decisions
-
-\* One such build system that tracks these correctly & efficiently is [Tup](http://gittup.org/tup/). See the (rather accessible!) paper [here](http://gittup.org/tup/build_system_rules_and_algorithms.pdf). Unfortunately, Tup's implementation uses FUSE and other systems, which we can't safely use on every platform.
+For more infos, run `bsb -help` to see all the available options.

--- a/pages/docs/manual/latest/build-overview.mdx
+++ b/pages/docs/manual/latest/build-overview.mdx
@@ -9,18 +9,6 @@ canonical: "/docs/manual/latest/build-overview"
 
 ReScript comes with a build system, bsb, that's meant to be fast, lean and used as the authoritative build system of the community.
 
-Bsb provides a few templates to quickly start a new project:
-
-```sh
-bsb -init my-directory-name
-```
-
-Feel free to inspect the various files in the newly generated directory. To see all the templates available, do:
-
-```sh
-bsb -themes
-```
-
 The build description file is called `bsconfig.json`. Every ReScript project needs one.
 
 **To build a project**, run:

--- a/pages/docs/manual/latest/build-pinned-dependencies.mdx
+++ b/pages/docs/manual/latest/build-pinned-dependencies.mdx
@@ -1,17 +1,22 @@
 ---
-title: "Monorepo Setup"
-metaTitle: "Monorepo Setup"
-description: "Configuring ReScript in a monorepo like setup"
-canonical: "/docs/manual/latest/build-monorepos"
+title: "Pinned Dependencies"
+metaTitle: "Pinned Dependencies"
+description: "Handling multiple packages within one ReScript project with pinned dependencies"
+canonical: "/docs/manual/latest/build-pinned-dependencies"
 ---
 
-# Monorepo Setup
+# Pinned Dependencies
 
 **Since 8.4**
 
-We usually recommend using ReScript in a single-codebase style, where there is only one `bsconfig.json` file for the whole codebase. Many JavaScript libraries maintain multiple packages in one single codebase though, and use `yarn workspaces` to cross-link packages locally for development.
+Usually we'd recommend to use ReScript in a single-codebase style: One `bsconfig.json` file for the whole codebase.
 
-This workflow is not straightforward for ReScript usage, so we need to explain some additional concepts to make this work. There are three different kinds of packages:
+There are scenarios where you still want to connect and build multiple independent ReScript packages for one main project though. This is where `pinned-dependencies` come into play.
+
+
+### Package Types
+
+Before we go into detail, let's first explain all the different package types recognized by the build system:
 
 - Toplevel (this is usually the final app you are building, which has dependencies to other packages)
 - Pinned dependencies (these are your local packages that should always rebuild when you build your toplevel, those should be listed in `bs-dependencies` and `pinned-dependencies`)
@@ -19,7 +24,7 @@ This workflow is not straightforward for ReScript usage, so we need to explain s
 
 Whenever a package is being built (`bsb -make-world`), the build system will build the toplevel package with its pinned-dependencies. So any changes made in a pinned dependency will automatically be reflected in the final app.
 
-## Build System Package Rules
+### Build System Package Rules
 
 The build system respects the following rules for each package type:
 
@@ -43,6 +48,8 @@ The build system respects the following rules for each package type:
 - Ignores dev directories
 - Ignores pinned dependencies
 - Ignores custom generator rules
+
+So with that knowledge in mind, let's dive into some more concrete examples to see our `pinned dependencies` in action.
 
 ## Examples
 

--- a/pages/docs/manual/latest/build-pinned-dependencies.mdx
+++ b/pages/docs/manual/latest/build-pinned-dependencies.mdx
@@ -14,7 +14,7 @@ Usually we'd recommend to use ReScript in a single-codebase style: One `bsconfig
 There are scenarios where you still want to connect and build multiple independent ReScript packages for one main project though. This is where `pinned-dependencies` come into play.
 
 
-### Package Types
+## Package Types
 
 Before we go into detail, let's first explain all the different package types recognized by the build system:
 
@@ -24,7 +24,7 @@ Before we go into detail, let's first explain all the different package types re
 
 Whenever a package is being built (`bsb -make-world`), the build system will build the toplevel package with its pinned-dependencies. So any changes made in a pinned dependency will automatically be reflected in the final app.
 
-### Build System Package Rules
+## Build System Package Rules
 
 The build system respects the following rules for each package type:
 

--- a/pages/docs/manual/latest/build-pinned-dependencies.mdx
+++ b/pages/docs/manual/latest/build-pinned-dependencies.mdx
@@ -9,9 +9,9 @@ canonical: "/docs/manual/latest/build-pinned-dependencies"
 
 **Since 8.4**
 
-Usually we'd recommend to use ReScript in a single-codebase style: One `bsconfig.json` file for the whole codebase.
+Usually we'd recommend to use ReScript in a single-codebase style by using one `bsconfig.json` file for your whole codebase.
 
-There are scenarios where you still want to connect and build multiple independent ReScript packages for one main project though. This is where `pinned-dependencies` come into play.
+There are scenarios where you still want to connect and build multiple independent ReScript packages for one main project though (`yarn workspaces`-like "monorepos"). This is where `pinned-dependencies` come into play.
 
 
 ## Package Types
@@ -49,7 +49,7 @@ The build system respects the following rules for each package type:
 - Ignores pinned dependencies
 - Ignores custom generator rules
 
-So with that knowledge in mind, let's dive into some more concrete examples to see our `pinned dependencies` in action.
+So with that knowledge in mind, let's dive into some more concrete examples to see our pinned dependencies in action.
 
 ## Examples
 

--- a/pages/docs/manual/latest/external.mdx
+++ b/pages/docs/manual/latest/external.mdx
@@ -16,7 +16,7 @@ canonical: "/docs/manual/latest/external"
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.val external setTimeout: (unit => unit, int) => float = "setTimeout"
+@val external setTimeout: (unit => unit, int) => float = "setTimeout"
 ```
 ```js
 // Empty output
@@ -26,9 +26,9 @@ canonical: "/docs/manual/latest/external"
 
 There are several kinds of `external`s, differentiated and/or augmented through the `@bs` notation they carry. This page deals with the general, shared mechanism behind most `external`s. The different `@bs` annotations are documented in their respective pages later. A few notable ones:
 
-- `@bs.val`, `@bs.scope`: [bind to global JS values](bind-to-global-js-values).
-- `@bs.module`: [bind to JS imported/exported values](import-from-export-to-js).
-- `@bs.send`: [bind to JS methods](bind-to-js-function).
+- `@val`, `@scope`: [bind to global JS values](bind-to-global-js-values).
+- `@module`: [bind to JS imported/exported values](import-from-export-to-js).
+- `@send`: [bind to JS methods](bind-to-js-function).
 
 ## Usage
 
@@ -43,7 +43,7 @@ Once declared, you can use an `external` as a normal value, just like a let bind
 ```res example
 // The type of document is just some random type 'a
 // that we won't bother to specify
-@bs.val external document: 'a = "document"
+@val external document: 'a = "document"
 
 // call a method
 document["addEventListener"]("mouseup", _event => {
@@ -78,7 +78,7 @@ However, if you want to more rigidly bind to the JavaScript library you want, ke
 
 Additionally, no extra ReScript-specific runtime is better for output readability.
 
-> **Note:** do also use `external`s and the `@bs.blabla` attributes in the interface files. Otherwise the inlining won't happen.
+> **Note:** do also use `external`s and the `@blabla` attributes in the interface files. Otherwise the inlining won't happen.
 
 ## Design Decisions
 

--- a/pages/docs/manual/latest/generate-converters-accessors.mdx
+++ b/pages/docs/manual/latest/generate-converters-accessors.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Generate Converters & Helpers"
-description: "All about the @bs.deriving decorator, and how to generate code from types"
+description: "All about the @deriving decorator, and how to generate code from types"
 canonical: "/docs/manual/latest/generate-converters-accessors"
 ---
 
@@ -14,20 +14,18 @@ When using ReScript, you will sometimes come into situations where you want to
 - Convert a record type into an abstract type with generated creation, accessor and method functions.
 - Generate some other helper functions, such as functions from record attribute names.
 
-You can use the `@bs.deriving` decorator for different code generation scenarios. All different options and configurations will be discussed on this page.
+You can use the `@deriving` decorator for different code generation scenarios. All different options and configurations will be discussed on this page.
 
 **Note:** Please be aware that extensive use of code generation might make it harder to understand your programs (since the code being generated is not visible in the source code, and you just need to know what kind of functions / values a decorator generates).
 
-**Another Note:** Since `v8.3` you can drop the `bs.` prefix for all our decorators (e.g. `@bs.deriving` => `@deriving`).
-
 ## Generate Functions & Plain Values for Variants
 
-Use `@bs.deriving(accessors)` on a variant type to create accessor functions for its constructors.
+Use `@deriving(accessors)` on a variant type to create accessor functions for its constructors.
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-@bs.deriving(accessors)
+@deriving(accessors)
 type action =
   | Click
   | Submit(string)
@@ -71,13 +69,13 @@ Please note that in case you just want to _pipe a payload into a constructor_, y
 
 ## Generate Field Accessors for Records
 
-Use `@bs.deriving(accessors)` on a record type to create accessors for its record field names.
+Use `@deriving(accessors)` on a record type to create accessors for its record field names.
 
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-@bs.deriving(accessors)
+@deriving(accessors)
 type pet = {name: string}
 
 let pets = [{name: "bob"}, {name: "bob2"}]
@@ -110,14 +108,14 @@ console.log(Belt_Array.map(pets, name).join("&"));
 ## Generate Converters for JS Object and Record
 
 > **Note:** In ReScript >= v7 [records are already compiled to JS
-> objects](bind-to-js-object#bind-to-record-like-js-objects). `@bs.deriving(jsConverter)` is therefore
+> objects](bind-to-js-object#bind-to-record-like-js-objects). `@deriving(jsConverter)` is therefore
 > obsolete and will generate a no-op function for compatibility instead.
 
-Use `@bs.deriving(jsConverter)` on a record type to create convertion functions between records / JS object runtime values.
+Use `@deriving(jsConverter)` on a record type to create convertion functions between records / JS object runtime values.
 
 
 ```res
-@bs.deriving(jsConverter)
+@deriving(jsConverter)
 type coordinates = {
   x: int,
   y: int
@@ -148,16 +146,16 @@ let jsCoordinates = coordinatesToJs({x: 1, y: 2});
 This binds to a `jsCoordinates` record (not a JS object!) that exists on the JS side, presumably created by JS calling the function `coordinatesFromJs`:
 
 ```res
-@bs.module("myGame")
+@module("myGame")
 external jsCoordinates : coordinates = "jsCoordinates";
 ```
 
 ### More Safety
 
-The above generated functions use JS object types. You can also hide this implementation detail by making the object type **abstract** by using the `newType` option with `@bs.deriving(jsConverter)`:
+The above generated functions use JS object types. You can also hide this implementation detail by making the object type **abstract** by using the `newType` option with `@deriving(jsConverter)`:
 
 ```res
-@bs.deriving({jsConverter: newType})
+@deriving({jsConverter: newType})
 type coordinates = {
   x: int,
   y: int,
@@ -190,10 +188,10 @@ Same generated output. Isn't it great that types prevent invalid accesses you'd 
 
 ## Generate Converters for JS Integer Enums and Variants
 
-Use `@bs.deriving(jsConverter)` on a variant type to create converter functions that allow back and forth conversion between JS integer enum and ReScript variant values.
+Use `@deriving(jsConverter)` on a variant type to create converter functions that allow back and forth conversion between JS integer enum and ReScript variant values.
 
 ```res
-@bs.deriving(jsConverter)
+@deriving(jsConverter)
 type fruit =
   | Apple
   | Orange
@@ -213,16 +211,16 @@ For `fruitToJs`, each fruit variant constructor would map into an integer, start
 
 For `fruitFromJs`, the return value is an `option`, because not every int maps to a constructor.
 
-You can also attach a `@bs.as(1234)` to each constructor to customize their output.
+You can also attach a `@as(1234)` to each constructor to customize their output.
 
 ### Usage
 
 ```res
-@bs.deriving(jsConverter)
+@deriving(jsConverter)
 type fruit =
   | Apple
-  | @bs.as(10) Orange
-  | @bs.as(100) Kiwi
+  | @as(10) Orange
+  | @as(100) Kiwi
   | Watermelon
 
 let zero = fruitToJs(Apple) /* 0 */
@@ -233,21 +231,21 @@ switch fruitFromJs(100) {
 }
 ```
 
-**Note**: by using `@bs.as` here, all subsequent number encoding changes. `Apple` is still `0`, `Orange` is `10`, `Kiwi` is `100` and `Watermelon` is **`101`**!
+**Note**: by using `@as` here, all subsequent number encoding changes. `Apple` is still `0`, `Orange` is `10`, `Kiwi` is `100` and `Watermelon` is **`101`**!
 
 ### More Safety
 
-Similar to the JS object <-> record deriving, you can hide the fact that the JS enum are ints by using the same `newType` option with `@bs.deriving(jsConverter)`:
+Similar to the JS object <-> record deriving, you can hide the fact that the JS enum are ints by using the same `newType` option with `@deriving(jsConverter)`:
 
 ```res
-@bs.deriving({jsConverter: newType})
+@deriving({jsConverter: newType})
 type fruit =
   | Apple
-  | @bs.as(100) Kiwi
+  | @as(100) Kiwi
   | Watermelon;
 ```
 
-This option causes `@bs.deriving(jsConverter)` to generate functions of the following types:
+This option causes `@deriving(jsConverter)` to generate functions of the following types:
 
 ```resi
 let fruitToJs: fruit => abs_fruit;
@@ -260,15 +258,15 @@ For `fruitFromJs`, the return value, unlike the previous non-abstract type case,
 #### Usage
 
 ```res
-@bs.deriving({jsConverter: newType})
+@deriving({jsConverter: newType})
 type fruit =
   | Apple
-  | @bs.as(100) Kiwi
+  | @as(100) Kiwi
   | Watermelon
 
 let opaqueValue = fruitToJs(Apple)
 
-@bs.module("myJSFruits") external jsKiwi: abs_fruit = "iSwearThisIsAKiwi"
+@module("myJSFruits") external jsKiwi: abs_fruit = "iSwearThisIsAKiwi"
 let kiwi = fruitFromJs(jsKiwi)
 
 let error = fruitFromJs(100) /* nope, can't take a random int */
@@ -276,17 +274,17 @@ let error = fruitFromJs(100) /* nope, can't take a random int */
 
 ## Generate Converters for JS String Enums and Polymorphic Variants
 
-> **Note**: Since ReScript v8.2, polymorphic variants are already compiled to strings, so this feature is getting deprecated at some point. It's currently still useful for aliasing JS output with `@bs.as`.
+> **Note**: Since ReScript v8.2, polymorphic variants are already compiled to strings, so this feature is getting deprecated at some point. It's currently still useful for aliasing JS output with `@as`.
 
-Similarly as with [generating int converters](#generate-converters-between-js-integer-enums-and-variants), use `@bs.deriving(jsConverter)` on a polymorphic variant type to create converter functions for JS string and ReScript poly variant values.
+Similarly as with [generating int converters](#generate-converters-between-js-integer-enums-and-variants), use `@deriving(jsConverter)` on a polymorphic variant type to create converter functions for JS string and ReScript poly variant values.
 
 ### Usage
 
 ```res
-@bs.deriving(jsConverter)
+@deriving(jsConverter)
 type fruit = [
   | #Apple
-  | @bs.as("miniCoconut") #Kiwi
+  | @as("miniCoconut") #Kiwi
   | #Watermelon
 ]
 
@@ -294,39 +292,39 @@ let appleString = fruitToJs(#Apple); /* "Apple" */
 let kiwiString = fruitToJs(#Kiwi); /* "miniCoconut" */
 ```
 
-As in similar use-cases before, you can also use `@bs.deriving({jsConverter: newType})` to generate abstract types instead.
+As in similar use-cases before, you can also use `@deriving({jsConverter: newType})` to generate abstract types instead.
 
 ## Convert Record Type to Abstract Record
 
 > **Note**: For ReScript >= v7, we recommend using [plain records to compile to JS objects](bind-to-js-object#bind-to-record-like-js-objects).
 > This feature might still be useful for certain scenarios, but the ergonomics might be worse
 
-Use `@bs.deriving(abstract)` on a record type to expand the type into a creation, and a set of getter / setter functions for fields and methods.
+Use `@deriving(abstract)` on a record type to expand the type into a creation, and a set of getter / setter functions for fields and methods.
 
-Usually you'd just use ReScript records to compile to JS objects of the same shape. There is still one particular use-case left where the `@bs.deriving(abstract)` convertion is still useful: Whenever you need compile a record with an optional field where the JS object attribute shouldn't show up in the resulting JS when undefined (e.g. `{name: "Carl", age: undefined}` vs `{name: "Carl"}`). Check the [Optional Labels](#optional-labels) section for more infos on this particular scenario.
+Usually you'd just use ReScript records to compile to JS objects of the same shape. There is still one particular use-case left where the `@deriving(abstract)` convertion is still useful: Whenever you need compile a record with an optional field where the JS object attribute shouldn't show up in the resulting JS when undefined (e.g. `{name: "Carl", age: undefined}` vs `{name: "Carl"}`). Check the [Optional Labels](#optional-labels) section for more infos on this particular scenario.
 
 ### Usage Example
 
 ```res
-@bs.deriving(abstract)
+@deriving(abstract)
 type person = {
   name: string,
   age: int,
   job: string,
 };
 
-@bs.val external john : person = "john";
+@val external john : person = "john";
 ```
 
-**Note**: the `person` type is **not** a record! It's a record-looking type that uses the record's syntax and type-checking. The `@bs.deriving(abstract)` decorator turns it into an "abstract type" (aka you don't know what the actual value's shape).
+**Note**: the `person` type is **not** a record! It's a record-looking type that uses the record's syntax and type-checking. The `@deriving(abstract)` decorator turns it into an "abstract type" (aka you don't know what the actual value's shape).
 
 ### Creation
 
 You don't have to bind to an existing `person` object from the JS side. You can also create such `person` JS object from ReScript's side.
 
-Since `@bs.deriving(abstract)` turns the above `person` record into an abstract type, you can't directly create a person record as you would usually. This doesn't work: `{name: "Joe", age: 20, job: "teacher"}`.
+Since `@deriving(abstract)` turns the above `person` record into an abstract type, you can't directly create a person record as you would usually. This doesn't work: `{name: "Joe", age: 20, job: "teacher"}`.
 
-Instead, you'd use the **creation function** of the same name as the record type, implicitly generated by the `@bs.deriving(abstract)` annotation:
+Instead, you'd use the **creation function** of the same name as the record type, implicitly generated by the `@deriving(abstract)` annotation:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
@@ -348,15 +346,15 @@ Note how in the example above there is no JS runtime overhead.
 
 #### Rename Fields
 
-Sometimes you might be binding to a JS object with field names that are invalid in ReScript. Two examples would be `{type: "foo"}` (reserved keyword in ReScript) and `{"aria-checked": true}`. Choose a valid field name then use `@bs.as` to circumvent this:
+Sometimes you might be binding to a JS object with field names that are invalid in ReScript. Two examples would be `{type: "foo"}` (reserved keyword in ReScript) and `{"aria-checked": true}`. Choose a valid field name then use `@as` to circumvent this:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-@bs.deriving(abstract)
+@deriving(abstract)
 type data = {
-  @bs.as("type") type_: string,
-  @bs.as("aria-label") ariaLabel: string,
+  @as("type") type_: string,
+  @as("aria-label") ariaLabel: string,
 };
 
 let d = data(~type_="message", ~ariaLabel="hello");
@@ -378,9 +376,9 @@ You can omit fields during the creation of the object:
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-@bs.deriving(abstract)
+@deriving(abstract)
 type person = {
-  @bs.optional name: string,
+  @optional name: string,
   age: int,
   job: string,
 };
@@ -399,17 +397,17 @@ var joe = {
 
 Optional values that are not defined, will not show up as an attribute in the resulting JS object. In the example above, you will see that `name` was omitted.
 
-**Note** that the `@bs.optional` tag turned the `name` field optional. Merely typing `name` as `option<string>` wouldn't work.
+**Note** that the `@optional` tag turned the `name` field optional. Merely typing `name` as `option<string>` wouldn't work.
 
 **Note**: now that your creation function contains optional fields, we mandate an unlabeled `()` at the end to indicate that [you've finished applying the function](function#optional-labeled-arguments).
 
 ### Accessors
 
-Again, since `@bs.deriving(abstract)` hides the actual record shape, you can't access a field using e.g. `joe.age`. We remediate this by generating getter and setters.
+Again, since `@deriving(abstract)` hides the actual record shape, you can't access a field using e.g. `joe.age`. We remediate this by generating getter and setters.
 
 #### Read
 
-One getter function is generated per `@bs.deriving(abstract)` record type field. In the above example, you'd get 3 functions: `nameGet`, `ageGet`, `jobGet`. They take in a `person` value and return `string`, `int`, `string` respectively:
+One getter function is generated per `@deriving(abstract)` record type field. In the above example, you'd get 3 functions: `nameGet`, `ageGet`, `jobGet`. They take in a `person` value and return `string`, `int`, `string` respectively:
 
 ```res
 let twenty = ageGet(joe)
@@ -424,7 +422,7 @@ let twenty = joe->ageGet
 If you prefer shorter names for the getter functions, we also support a `light` setting:
 
 ```res
-@bs.deriving({abstract: light})
+@deriving({abstract: light})
 type person = {
   name: string,
   age: int,
@@ -438,10 +436,10 @@ The getter functions will now have the same names as the object fields themselve
 
 #### Write
 
-A `@bs.deriving(abstract)` value is immutable by default. To mutate such value, you need to first mark one of the abstract record field as `mutable`, the same way you'd mark a normal record as mutable:
+A `@deriving(abstract)` value is immutable by default. To mutate such value, you need to first mark one of the abstract record field as `mutable`, the same way you'd mark a normal record as mutable:
 
 ```res
-@bs.deriving(abstract)
+@deriving(abstract)
 type person = {
   name: string,
   mutable age: int,
@@ -464,11 +462,11 @@ joe->ageSet(21)
 
 ### Methods
 
-You can attach arbitrary methods onto a type (_any_ type, as a matter of fact. Not just `@bs.deriving(abstract)` record types). See [Object Method](bind-to-js-function#object-method) in the "Bind to JS Function" section for more infos.
+You can attach arbitrary methods onto a type (_any_ type, as a matter of fact. Not just `@deriving(abstract)` record types). See [Object Method](bind-to-js-function#object-method) in the "Bind to JS Function" section for more infos.
 
 ### Tips & Tricks
 
-You can leverage `@bs.deriving(abstract)` for finer-grained access control.
+You can leverage `@deriving(abstract)` for finer-grained access control.
 
 #### Mutability
 
@@ -476,18 +474,18 @@ You can mark a field as mutable in the implementation (`.res`) file, while _hidi
 
 ```res
 /* test.res */
-@bs.deriving(abstract)
+@deriving(abstract)
 type cord = {
-  @bs.optional mutable x: int,
+  @optional mutable x: int,
   y: int,
 };
 ```
 
 ```resi
 /* test.resi */
-@bs.deriving(abstract)
+@deriving(abstract)
 type cord = {
-  @bs.optional x: int,
+  @optional x: int,
   y: int,
 };
 ```
@@ -499,9 +497,9 @@ Tada! Now you can mutate inside your own file as much as you want, and prevent o
 Mark the record as `private` to disable the creation function:
 
 ```res
-@bs.deriving(abstract)
+@deriving(abstract)
 type cord = private {
-  @bs.optional x: int,
+  @optional x: int,
   y: int,
 }
 ```
@@ -517,10 +515,10 @@ same scope where the type is defined, you will eventually run into value shadowi
 **For example:**
 
 ```res
-@bs.deriving(abstract)
+@deriving(abstract)
 type person = {name: string}
 
-@bs.deriving(abstract)
+@deriving(abstract)
 type cat = {
   name: string,
   isLazy: bool,
@@ -538,12 +536,12 @@ functions and later use them via local open statements:
 
 ```res
 module Person = {
-  @bs.deriving(abstract)
+  @deriving(abstract)
   type t = {name: string}
 }
 
 module Cat = {
-  @bs.deriving(abstract)
+  @deriving(abstract)
   type t = {
     name: string,
     isLazy: bool,
@@ -569,7 +567,7 @@ let whisperCatName = {
 
 ## Convert External into JS Object Creation Function
 
-Use `@bs.obj` on an `external` binding to create a function that, when called, will evaluate to a JS object with fields corresponding to the function's parameter labels.
+Use `@obj` on an `external` binding to create a function that, when called, will evaluate to a JS object with fields corresponding to the function's parameter labels.
 
 This is very handy because you can make some of those labelled parameters optional and if you don't pass them in, the output object won't include the corresponding fields. Thus you can use it to dynamically create objects with the subset of fields you need at runtime.
 
@@ -588,7 +586,7 @@ var homeRoute = {
 But only the first three fields are required; the options field is optional. You can declare the binding function like so:
 
 ```res
-@bs.obj
+@obj
 external route: (
   ~\"type": string,
   ~path: string,

--- a/pages/docs/manual/latest/import-from-export-to-js.mdx
+++ b/pages/docs/manual/latest/import-from-export-to-js.mdx
@@ -25,13 +25,13 @@ The format is [configurable in bsb](build-configuration.md#package-specs).
 
 ### Import a JavaScript Module's Named Export
 
-Use the `bs.module` [external](external.md):
+Use the `module` [external](external.md):
 
 <CodeTab labels={["ReScript", "JS Output (CommonJS)", "JS Output (ES6)"]}>
 
 ```res example
 // Import nodejs' path.dirname
-@bs.module("path") external dirname: string => string = "dirname"
+@module("path") external dirname: string => string = "dirname"
 let root = dirname("/User/github") // returns "User"
 ```
 ```js
@@ -47,7 +47,7 @@ var root = Path.dirname("/User/github");
 
 Here's what the `external` does:
 
-- `@bs.module("path")`: pass the name of the JS module; in this case, `"path"`. The string can be anything: `"./src/myJsFile"`, `"@myNpmNamespace/myLib"`, etc.
+- `@module("path")`: pass the name of the JS module; in this case, `"path"`. The string can be anything: `"./src/myJsFile"`, `"@myNpmNamespace/myLib"`, etc.
 - `external`: the general keyword for declaring a value that exists on the JS side.
 - `dirname`: the binding name you'll use on the ReScript side.
 - `string => string`: the type signature of `dirname`. Mandatory for `external`s.
@@ -55,12 +55,12 @@ Here's what the `external` does:
 
 ### Import a JavaScript Module As a Single Value
 
-By omitting the string argument to `bs.module`, you bind to the whole JS module:
+By omitting the string argument to `module`, you bind to the whole JS module:
 
 <CodeTab labels={["ReScript", "JS Output (CommonJS)", "JS Output (ES6)"]}>
 
 ```res example
-@bs.module external leftPad: string => int => string = "./leftPad"
+@module external leftPad: string => int => string = "./leftPad"
 let paddedResult = leftPad("hi", 5)
 ```
 ```js
@@ -83,7 +83,7 @@ Use the value `"default"` on the right hand side:
 <CodeTab labels={["ReScript", "JS Output (ES6)"]}>
 
 ```res example
-@bs.module("./student") external studentName: string = "default"
+@module("./student") external studentName: string = "default"
 Js.log(studentName)
 ```
 ```js

--- a/pages/docs/manual/latest/inlining-constants.mdx
+++ b/pages/docs/manual/latest/inlining-constants.mdx
@@ -29,7 +29,7 @@ So, in ReScript, producing that example `if (process.env.mode === 'development')
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.val external process: 'a = "process"
+@val external process: 'a = "process"
 
 let mode = "development"
 
@@ -47,14 +47,14 @@ if (process.env.mode === mode) {
 
 </CodeTab>
 
-The JS output shows `if (process.env.mode === mode)`, which isn't what we wanted. To inline `mode`'s value, use `@bs.inline`:
+The JS output shows `if (process.env.mode === mode)`, which isn't what we wanted. To inline `mode`'s value, use `@inline`:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.val external process: 'a = "process"
+@val external process: 'a = "process"
 
-@bs.inline
+@inline
 let mode = "development"
 
 if (process["env"]["mode"] === mode) {

--- a/pages/docs/manual/latest/interop-cheatsheet.mdx
+++ b/pages/docs/manual/latest/interop-cheatsheet.mdx
@@ -10,7 +10,7 @@ This is a glossary with examples. All the features are described by later pages.
 
 ## List of Decorators
 
-> **Note:** In previous versions (< 8.4) all our attributes started with a `bs.` prefix. Our formatter will automatically drop them in newer ReScript versions.
+> **Note:** In previous versions (< 8.3) all our attributes started with a `bs.` prefix. Our formatter will automatically drop them in newer ReScript versions.
 
 <!-- Synced from https://github.com/rescript-lang/syntax/blob/123760c5a264da5288eeee5213ddd25eb86d62fe/src/res_printer.ml#L19-L51 -->
 

--- a/pages/docs/manual/latest/interop-cheatsheet.mdx
+++ b/pages/docs/manual/latest/interop-cheatsheet.mdx
@@ -10,33 +10,35 @@ This is a glossary with examples. All the features are described by later pages.
 
 ## List of Decorators
 
+> **Note:** In previous versions (< 8.4) all our attributes started with a `bs.` prefix. Our formatter will automatically drop them in newer ReScript versions.
+
 <!-- Synced from https://github.com/rescript-lang/syntax/blob/123760c5a264da5288eeee5213ddd25eb86d62fe/src/res_printer.ml#L19-L51 -->
 
 ### Attributes
 
-- `@bs.as`: [here](attribute#usage), [here](bind-to-js-function#fixed-arguments), [here](bind-to-js-function#constrain-arguments-better) and [here](generate-converters-accessors#usage-3)
-- [`@bs.deriving`](generate-converters-accessors#generate-functions--plain-values-for-variants)
-- [`@bs.get`](bind-to-js-object#bind-using-special-bs-getters--setters)
-- [`@bs.get_index`](bind-to-js-object#bind-using-special-bs-getters--setters)
-<!-- - `@bs.ignore` -->
-- [`@bs.inline`](inlining-constants)
-- [`@bs.int`](bind-to-js-function#constrain-arguments-better)
-<!-- - `@bs.meth` -->
-- [`@bs.module`](import-from-export-to-js#import-a-javascript-modules-content)
-- [`@bs.new`](bind-to-js-object#bind-to-a-js-object-thats-a-class)
-- [`@bs.obj`](generate-converters-accessors#convert-external-into-js-object-creation-function)
-- [`@bs.optional`](generate-converters-accessors#optional-labels)
-- [`@bs.return`](bind-to-js-function#function-nullable-return-value-wrapping)
-- `@bs.send`: [here](bind-to-js-function#object-method) and [here](pipe#js-method-chaining)
-- [`@bs.scope`](bind-to-global-js-values#global-modules)
-- [`@bs.set`](bind-to-js-object#bind-using-special-bs-getters--setters)
-- [`@bs.set_index`](bind-to-js-object#bind-using-special-bs-getters--setters)
-- [`@bs.variadic`](bind-to-js-function#variadic-function-arguments)
-- [`@bs.string`](bind-to-js-function#constrain-arguments-better)
-- [`@bs.this`](bind-to-js-function#modeling-this-based-callbacks)
-- [`@bs.uncurry`](bind-to-js-function#extra-solution)
-- [`@bs.unwrap`](bind-to-js-function#trick-2-polymorphic-variant--bsunwrap)
-- [`@bs.val`](bind-to-global-js-values#global-modules)
+- `@as`: [here](attribute#usage), [here](bind-to-js-function#fixed-arguments), [here](bind-to-js-function#constrain-arguments-better) and [here](generate-converters-accessors#usage-3)
+- [`@deriving`](generate-converters-accessors#generate-functions--plain-values-for-variants)
+- [`@get`](bind-to-js-object#bind-using-special-bs-getters--setters)
+- [`@get_index`](bind-to-js-object#bind-using-special-bs-getters--setters)
+<!-- - `@ignore` -->
+- [`@inline`](inlining-constants)
+- [`@int`](bind-to-js-function#constrain-arguments-better)
+<!-- - `@meth` -->
+- [`@module`](import-from-export-to-js#import-a-javascript-modules-content)
+- [`@new`](bind-to-js-object#bind-to-a-js-object-thats-a-class)
+- [`@obj`](generate-converters-accessors#convert-external-into-js-object-creation-function)
+- [`@optional`](generate-converters-accessors#optional-labels)
+- [`@return`](bind-to-js-function#function-nullable-return-value-wrapping)
+- `@send`: [here](bind-to-js-function#object-method) and [here](pipe#js-method-chaining)
+- [`@scope`](bind-to-global-js-values#global-modules)
+- [`@set`](bind-to-js-object#bind-using-special-bs-getters--setters)
+- [`@set_index`](bind-to-js-object#bind-using-special-bs-getters--setters)
+- [`@variadic`](bind-to-js-function#variadic-function-arguments)
+- [`@string`](bind-to-js-function#constrain-arguments-better)
+- [`@this`](bind-to-js-function#modeling-this-based-callbacks)
+- [`@uncurry`](bind-to-js-function#extra-solution)
+- [`@unwrap`](bind-to-js-function#trick-2-polymorphic-variant--bsunwrap)
+- [`@val`](bind-to-global-js-values#global-modules)
 
 - [`@deprecated`](attribute#usage)
 - [`genType`](https://github.com/reason-association/genType)
@@ -74,7 +76,7 @@ const a = 1
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.val external setTimeout: (unit => unit, int) => float = "setTimeout"
+@val external setTimeout: (unit => unit, int) => float = "setTimeout"
 ```
 ```js
 // Empty output
@@ -87,12 +89,12 @@ const a = 1
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.val @bs.scope("Math")
+@val @scope("Math")
 external random: unit => float = "random"
 
 let someNumber = random()
 
-@bs.val @bs.scope(("window", "location", "ancestorOrigins"))
+@val @scope(("window", "location", "ancestorOrigins"))
 external length: int = "length"
 ```
 ```js
@@ -153,8 +155,8 @@ var result3 = Caml_option.nullable_to_opt(10);
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.send external map: (array<'a>, 'a => 'b) => array<'b> = "map"
-@bs.send external filter: (array<'a>, 'a => 'b) => array<'b> = "filter"
+@send external map: (array<'a>, 'a => 'b) => array<'b> = "map"
+@send external filter: (array<'a>, 'a => 'b) => array<'b> = "filter"
 [1, 2, 3]
   ->map(a => a + 1)
   ->filter(a => mod(a, 2) == 0)
@@ -179,7 +181,7 @@ console.log(
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.module("path") @bs.variadic
+@module("path") @variadic
 external join: array<string> => string = "join"
 ```
 ```js
@@ -193,8 +195,8 @@ external join: array<string> => string = "join"
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.module("Drawing") external drawCat: unit => unit = "draw"
-@bs.module("Drawing") external drawDog: (~giveName: string) => unit = "draw"
+@module("Drawing") external drawCat: unit => unit = "draw"
+@module("Drawing") external drawDog: (~giveName: string) => unit = "draw"
 ```
 ```js
 // Empty output
@@ -205,10 +207,10 @@ external join: array<string> => string = "join"
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.val
+@val
 external padLeft: (
   string,
-  @bs.unwrap [
+  @unwrap [
     | #Str(string)
     | #Int(int)
   ])

--- a/pages/docs/manual/latest/json.mdx
+++ b/pages/docs/manual/latest/json.mdx
@@ -17,7 +17,7 @@ Bind to JavaScript's `JSON.parse` and type the return value as the type you're e
 type data = {names: array<string>}
 
 // bind to JS' JSON.parse
-@bs.scope("JSON") @bs.val
+@scope("JSON") @val
 external parseIntoMyData: string => data = "parse"
 
 let result = parseIntoMyData(`{"names": ["Luke", "Christine"]}`)

--- a/pages/docs/manual/latest/libraries.mdx
+++ b/pages/docs/manual/latest/libraries.mdx
@@ -14,6 +14,8 @@ ReScript libraries are just like JavaScript libraries: published & hosted on [NP
 
 We recommend you to check in your compiled JavaScript output, for its [various benefits](interop-with-js-build-systems.md#popular-js-build-systems). If not, then at least consider publishing the JavaScript output by un-ignoring them in your [npmignore](https://docs.npmjs.com/cli/v7/using-npm/developers#keeping-files-out-of-your-package). This way, your published ReScript package comes with plain JavaScript files that JS users can consume. If your project's good, JS users might not even realize that they've installed a library written in ReScript!
 
+In case your library is only consumed by JS users, you may want to check out our [external stdlib](./build-external-stdlib) configuration as well.
+
 ### Find Libraries
 
 Search `rescript`-related packages on NPM, or use our [Package Index](/packages).

--- a/pages/docs/manual/latest/module.mdx
+++ b/pages/docs/manual/latest/module.mdx
@@ -140,6 +140,23 @@ var p = School.getProfession(School.person1);
 
 </CodeTab>
 
+### Use `open!` to ignore shadow warnings
+
+There are situations where `open` will cause a warning due to existing identifiers (bindings, types) being redefined. Use `open!` to explicitly tell the compiler that this is desired behavior.
+
+```res
+let map = (arr, value) => {
+  value
+}
+
+// opening Js.Array2 would shadow our previously defined `map`
+// `open!` will explicitly turn off the automatic warning
+open! Js.Array2
+let arr = map([1,2,3], (a) => { a + 1})
+```
+
+**Note:** Same as with `open`, don't overuse `open!` statements if not necessary. Use (sub)modules to prevent shadowing issues.
+
 ### Extending modules
 
 Using `include` in a module statically "spreads" a module's content into a new one, thus often fulfill the role of "inheritance" or "mixin".

--- a/pages/docs/manual/latest/module.mdx
+++ b/pages/docs/manual/latest/module.mdx
@@ -517,6 +517,17 @@ module MakeSet: MakeSetType = (Item: Comparable) => {
 
 </CodeTab>
 
+## Exotic Module Filenames
+
+**Since 8.3**
+
+It is possible to use non-conventional characters in your filenames (which is sometimes needed for specific JS frameworks). Here are some examples:
+
+- `src/Button.ios.res`
+- `pages/[id].res`
+
+Please note that modules with an exotic filename will not be accessible from other ReScript modules.
+
 ## Tips & Tricks
 
 Modules and functors are at a different "layer" of language than the rest (functions, let bindings, data structures, etc.). For example, you can't easily pass them into a tuple or record. Use them judiciously, if ever! Lots of times, just a record or a function is enough.

--- a/pages/docs/manual/latest/null-undefined-option.mdx
+++ b/pages/docs/manual/latest/null-undefined-option.mdx
@@ -170,7 +170,7 @@ If you're receiving, for example, a JS string that can be `null` and `undefined`
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.module("MyConstant") external myId: Js.Nullable.t<string> = "myId"
+@module("MyConstant") external myId: Js.Nullable.t<string> = "myId"
 ```
 ```js
 // Empty output
@@ -183,7 +183,7 @@ To create such a nullable string from our side (presumably to pass it to the JS 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-@bs.module("MyIdValidator") external validate: Js.Nullable.t<string> => bool = "validate"
+@module("MyIdValidator") external validate: Js.Nullable.t<string> => bool = "validate"
 let personId: Js.Nullable.t<string> = Js.Nullable.return("abc123")
 
 let result = validate(personId)

--- a/pages/docs/manual/latest/object.mdx
+++ b/pages/docs/manual/latest/object.mdx
@@ -112,10 +112,10 @@ Disallowed unless the object is a binding that comes from the JavaScript side. I
 
 ```res example
 type student = {
-  @bs.set "age": int,
-  @bs.set "name": string,
+  @set "age": int,
+  @set "name": string,
 }
-@bs.module("MyJSFile") external student1: student = "student1"
+@module("MyJSFile") external student1: student = "student1"
 
 student1["name"] = "Mary"
 ```
@@ -135,7 +135,7 @@ Since objects don't require type declarations, and since ReScript infers all the
 ```res example
 // The type of document is just some random type 'a
 // that we won't bother to specify
-@bs.val external document: 'a = "document"
+@val external document: 'a = "document"
 
 // call a method
 document["addEventListener"]("mouseup", _event => {

--- a/pages/docs/manual/latest/pattern-matching-destructuring.mdx
+++ b/pages/docs/manual/latest/pattern-matching-destructuring.mdx
@@ -433,7 +433,7 @@ if (typeof myStatus === "number" || myStatus.TAG) {
 
 Slightly more verbose, but a one-time writing effort. This helps when you add a new variant case e.g. `Quarantined` to the `status` type and need to update the places that pattern match on it. A top-level wildcard here would have accidentally and silently continued working, potentially causing bugs.
 
-### When Clause
+### If Clause
 
 Sometime, you want to check more than the shape of a value. You want to also run some arbitrary check on it. You might be tempted to write this:
 
@@ -469,7 +469,7 @@ if (person1.TAG) {
 ```res example
 switch person1 {
 | Teacher(_) => () // do nothing
-| Student({reportCard: {gpa}}) when gpa < 0.5 =>
+| Student({reportCard: {gpa}}) if gpa < 0.5 =>
   Js.log("What's happening")
 | Student(_) =>
   // fall-through, catch-all case
@@ -487,6 +487,8 @@ if (person1.TAG) {
 ```
 
 </CodeTab>
+
+**Note:** In ReScript version < 9.0, the `if` clause is denoted as a `when`, but will be reformatted to `if` in newer versions.
 
 ### Match on Exceptions
 

--- a/pages/docs/manual/latest/polymorphic-variant.mdx
+++ b/pages/docs/manual/latest/polymorphic-variant.mdx
@@ -86,9 +86,9 @@ In rare cases (mostly for JS interop reasons), it's also possible to define "inv
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-type numbers = [#\"1" | #\"2"]
-let one = #\"1"
-let oneA = #\"1a"
+type numbers = [#"1" | #"2"]
+let one = #"1"
+let oneA = #"1a"
 ```
 
 ```js
@@ -98,7 +98,7 @@ var oneA = "1a";
 
 </CodeTab>
 
-**Note:** The `\` character will be dropped in future ReScript versions for a cleaner look (`#"1"`).
+**Note:** For ReScript versions < 9.0 you'll need to use the `\` character as an escape sequence to represent invalid identifiers (e.g. `#\"1"`).
 
 ### Constructor Arguments
 

--- a/scripts/test-examples.js
+++ b/scripts/test-examples.js
@@ -9,7 +9,7 @@ let tempFileNameRegex = /_tempFile\.res/g
 // TODO: In the future we need to use the appropriate rescript version for each doc version variant
 //       see the package.json on how to define another rescript version
 let compilersDir = path.join(__dirname, "..", "compilers")
-let bsc = path.join(compilersDir, 'node_modules', 'rescript-820', process.platform, 'bsc.exe')
+let bsc = path.join(compilersDir, 'node_modules', 'rescript-902', process.platform, 'bsc.exe')
 
 const prepareCompilers = () => {
   if (fs.existsSync(bsc)) {
@@ -76,7 +76,8 @@ glob.sync(__dirname + '/../pages/docs/manual/latest/**/*.mdx').forEach((file) =>
   if (parsedResult != null) {
     fs.writeFileSync(tempFileName, parsedResult)
     try {
-      child_process.execFileSync(bsc, ['-i', tempFileName], {stdio: 'pipe'})
+      // -109 for suppressing `Toplevel expression is expected to have unit type.`
+      child_process.execFileSync(bsc, ['-i', tempFileName, '-w', '-109'], {stdio: 'pipe'})
     } catch (e) {
       process.stdout.write(postprocessOutput(file, e))
       success = false

--- a/src/Playground.js
+++ b/src/Playground.js
@@ -1336,7 +1336,7 @@ function Playground$Settings(Props) {
     evt.preventDefault();
     return Curry._1(setConfig, {
                 module_system: "nodejs",
-                warn_flags: "+a-4-9-20-40-41-42-50-61-102"
+                warn_flags: "+a-4-9-20-40-41-42-50-61-102-109"
               });
   };
   var titleClass = "text-18 font-bold mb-2";

--- a/src/Playground.res
+++ b/src/Playground.res
@@ -1036,7 +1036,7 @@ module Settings = {
       ReactEvent.Mouse.preventDefault(evt)
       let defaultConfig = {
         Api.Config.module_system: "nodejs",
-        warn_flags: "+a-4-9-20-40-41-42-50-61-102",
+        warn_flags: "+a-4-9-20-40-41-42-50-61-102-109",
       }
       setConfig(defaultConfig)
     }

--- a/src/common/Constants.js
+++ b/src/common/Constants.js
@@ -4,7 +4,7 @@
 var allManualVersions = [
   [
     "latest",
-    "v8.2.0"
+    "v8.4.0"
   ],
   [
     "v8.0.0",

--- a/src/common/Constants.js
+++ b/src/common/Constants.js
@@ -4,7 +4,7 @@
 var allManualVersions = [
   [
     "latest",
-    "v8.4.0"
+    "v9.x"
   ],
   [
     "v8.0.0",

--- a/src/common/Constants.res
+++ b/src/common/Constants.res
@@ -1,5 +1,5 @@
 // This is used for the version dropdown in the manual layouts
-let allManualVersions = [("latest", "v8.2.0"), ("v8.0.0", "< v8.2.0")]
+let allManualVersions = [("latest", "v8.4.0"), ("v8.0.0", "< v8.2.0")]
 
 // Used for the DocsOverview and collapsible navigation
 let languageManual = version => {

--- a/src/common/Constants.res
+++ b/src/common/Constants.res
@@ -1,5 +1,5 @@
 // This is used for the version dropdown in the manual layouts
-let allManualVersions = [("latest", "v8.4.0"), ("v8.0.0", "< v8.2.0")]
+let allManualVersions = [("latest", "v9.x"), ("v8.0.0", "< v8.2.0")]
 
 // Used for the DocsOverview and collapsible navigation
 let languageManual = version => {

--- a/src/common/WarningFlagDescription.js
+++ b/src/common/WarningFlagDescription.js
@@ -288,6 +288,10 @@ var numeric = [
   [
     108,
     "BuckleScript warning: Uninterpreted delimiters (for unicode)"
+  ],
+  [
+    109,
+    "Toplevel expression has unit type"
   ]
 ];
 

--- a/src/common/WarningFlagDescription.res
+++ b/src/common/WarningFlagDescription.res
@@ -1,6 +1,3 @@
-// This file was automatically converted to ReScript from 'WarningFlagDescription.re'
-// Check the output and make sure to delete the original file
-
 let numeric = [
   (1, "Suspicious-looking start-of-comment mark."),
   (2, "Suspicious-looking end-of-comment mark."),
@@ -90,6 +87,7 @@ let numeric = [
     "BuckleScript warning: Integer literal exceeds the range of representable integers of type int",
   ),
   (108, "BuckleScript warning: Uninterpreted delimiters (for unicode)"),
+  (109, "Toplevel expression has unit type"),
 ]
 
 let lastWarningNumber = 108


### PR DESCRIPTION
Unrelated to version:

- (done)Add `open!` docs

8.3:
- (done) remove `bs.` prefix from the attributes
- (done) Allow more character sets in module names (.something.res)
- (done) Fix Js.Array / Js.Array2 (https://github.com/rescript-lang/rescript-compiler/pull/4597/files)

8.4:
- (done) monorepo support feature [pinned deps](https://rescript-lang.org/blog/bucklescript-release-8-4#introducing-pinned-dependencies) 
- (done) introduce a new warning 109: toplevel expression is expected to have type unit It is turned on as warn-error by default.  This warning is introduced to avoid partial application errors in a curried language

Upgrade to 9.0:
- (done) Implement light weight syntax for poly-variants
- (done) New external stdlib improvement (https://rescript-lang.org/blog/release-9-0#new-external-stdlib-configuration)
- (done) when -> if (https://rescript-lang.org/blog/release-9-0#when---if)
