### PR TITLE
Fix typo in workspaces example

### DIFF
--- a/pages/docs/manual/latest/build-pinned-dependencies.mdx
+++ b/pages/docs/manual/latest/build-pinned-dependencies.mdx
@@ -81,7 +81,7 @@ Our `package.json` file within our codebase root would look like this:
     "packages": [
       "app",
       "common",
-      "legacy"
+      "myplugin"
     ]
   }
 }


### PR DESCRIPTION
Looks like the original idea of the example was some `legacy` package which later became `myplugin`