### PR TITLE
Remove custom blog category

### DIFF
--- a/_blogposts/2020-08-10-bucklescript-is-rebranding.mdx
+++ b/_blogposts/2020-08-10-bucklescript-is-rebranding.mdx
@@ -1,7 +1,6 @@
 ---
 author: rescript-team
 date: "2020-08-10"
-category: compiler
 badge: roadmap
 title: "BuckleScript & Reason Rebranding"
 description: A new unified experience for the platform

--- a/_blogposts/2020-08-28-new-rescript-logo.mdx
+++ b/_blogposts/2020-08-28-new-rescript-logo.mdx
@@ -2,7 +2,6 @@
 author: made_by_betty
 date: "2020-08-27"
 title: "A New Logo for ReScript"
-category: "ecosystem"
 previewImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1598616442/Reason%20Association/rescript-lang.org/Art-3-rescript-launch_ovoibg.jpg
 articleImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1598616442/Reason%20Association/rescript-lang.org/ReScript-3_by4q2u.jpg
 description: |

--- a/_blogposts/2020-09-25-release-8-3-2.mdx
+++ b/_blogposts/2020-09-25-release-8-3-2.mdx
@@ -1,15 +1,14 @@
 ---
 author: hongbo
-date: "2020-09-26" 
+date: "2020-09-26"
 previewImg:
-category: compiler
 title: What's new in ReScript 8.3 (Part 2)
 description: |
 ---
 
 ## Introduction
 
-ReScript is a soundly typed language with an optimizing compiler focused on the JS platform. 
+ReScript is a soundly typed language with an optimizing compiler focused on the JS platform.
 It's focused on type safety, performance and JS interop. It used to be called BuckleScript.
 
 [ReScript@8.3](https://www.npmjs.com/package/bs-platform/v/8.3.0) is now available for testing, you can try it via
@@ -18,47 +17,47 @@ It's focused on type safety, performance and JS interop. It used to be called Bu
 npm i bs-platform@8.3.1
 ```
 
-Following the [previous post](/blog/release-8-3-pt1), in this post we will go through 
+Following the [previous post](/blog/release-8-3-pt1), in this post we will go through
 the enhancement over the build system.
 
 ## Performance enhancement
 
-The underlying build engine for `bsb` is [ninja](https://ninja-build.org/), it is famous for 
+The underlying build engine for `bsb` is [ninja](https://ninja-build.org/), it is famous for
 [being fast](https://www.aosabook.org/en/posa/ninja.html)
 to build large C++ repos.
 
-In the last releases, we did lots of work for vertical integration into the bsb build chain. 
+In the last releases, we did lots of work for vertical integration into the bsb build chain.
 For example, we replaced the dynamic dependency parser with a minimal specialized one for bsb.
 we also removed the static dependencies parser which is only used for parsing C++ compiler output.
 
 Thanks to various other low-level improvements, the final outcome is quite impressive.
 For example, The binary size for [Mac platform](https://github.com/ninja-build/ninja/releases/tag/v1.10.1) is 270 KB
-while our vendored version is only 136KB. This is a non-trivial gain given that ninja is minimalist and already 
+while our vendored version is only 136KB. This is a non-trivial gain given that ninja is minimalist and already
 optimized by top-level C++ experts.
 
-Note such vertical integration not only brings better performance, smaller sizes, it also brings new features 
+Note such vertical integration not only brings better performance, smaller sizes, it also brings new features
 
 ## Build system enhancements for editor diagnostics
 
 When people are coding in their favorite editors, they expect to see syntax and type errors in real-time.
 There are multiple ways to achieve this. The most reliable way is to always invoke the build system whenever the user saves a file. Due to not having an in-memory cache, our build system is very reliable. However we didn't yet optimize the build system for live feedback in editors.
-what syntax errors, type checking errors do they have when editing? There are multiple ways to achieve this, the most easy 
-and reliable way is to always invoke the build system whenever the user saves the files, since it's the same build system 
+what syntax errors, type checking errors do they have when editing? There are multiple ways to achieve this, the most easy
+and reliable way is to always invoke the build system whenever the user saves the files, since it's the same build system
 without any in-memory cache, the reliability is very high, however, there's several challenges to use the build system output as editor diagnostics.
 
 ### The build system/compiler has to be fast to deliver real-time feedback
 
 Our build system is fast enough to deliver feedback for reasonable sized projects in less than 100ms.
-thanks to our previous [hard work](/blog/scalable). We continue improving 
+thanks to our previous [hard work](/blog/scalable). We continue improving
 Pushing the limits of performance in the build system allows us to provide real-time feedback in editors.
 
 ### The warnings for each file should not be flushed during a rebuild
 
 For a typical file based build system, if the file A is compiled successfully with some warnings, the rebuild will not build A anymore.
-This is problematic if we use the build system output for editor diagnostics. Since the second build will not capture those warnings, we 
+This is problematic if we use the build system output for editor diagnostics. Since the second build will not capture those warnings, we
 could use some caching mechanism to cache previous build output. But… stateful systems are not reliable and come with a whole range of different problems.
 
-To solve such a challenging problem, we did some innovations to co-ordinate the compiler and build system. When the file A is compiled with warnings, 
+To solve such a challenging problem, we did some innovations to co-ordinate the compiler and build system. When the file A is compiled with warnings,
 the compiler will produce some marks to the build system, the build system will keep building but such marks are encoded in the build rules
 so that the second build will do the rebuild.
 
@@ -80,15 +79,15 @@ We write the output to `.compiler.log` per each build, allowing clients to read 
 
 ## A better algorithm for removing stale outputs
 
-Whenever we rename a file, e.g. `a.res` to `b.res`, will lead to the output of `a.res` being stale. Thanks to the deeper integration of the build system and compiler, 
+Whenever we rename a file, e.g. `a.res` to `b.res`, will lead to the output of `a.res` being stale. Thanks to the deeper integration of the build system and compiler,
 we employ a more advanced strategy to remove stale outputs in this release. Pruning stale outputs is done in the beginning of each build.
 
 There are two ways of removing staled artifacts, the second one is introduced in this release:
 
 - Based on live analysis and prebuilt-in knowledge
 
-We scan `lib/bs` directory and check some dangling cm{i,t,j,ti} files, if it does not exist in 
-the current build set, it is considered stale artifacts. If it is `cmt` file, it would trigger some hooks of `genType`, notably -cmt-rm. 
+We scan `lib/bs` directory and check some dangling cm{i,t,j,ti} files, if it does not exist in
+the current build set, it is considered stale artifacts. If it is `cmt` file, it would trigger some hooks of `genType`, notably -cmt-rm.
 
 - Based on previous build logs
 We store previous compilation stats.  If a file is in the previous compiler output, but no longer in the output of the new build, it is considered stale and can be removed.

--- a/_blogposts/2020-09-25-release-8-3.mdx
+++ b/_blogposts/2020-09-25-release-8-3.mdx
@@ -1,15 +1,14 @@
 ---
 author: hongbo
-date: "2020-09-25" 
+date: "2020-09-25"
 previewImg:
-category: compiler
 title: What's new in ReScript 8.3 (Part 1)
 description: |
 ---
 
 ## Introduction
 
-ReScript is a soundly typed language with an optimizing compiler focused on the JS platform. 
+ReScript is a soundly typed language with an optimizing compiler focused on the JS platform.
 It's focused on type safety, performance and JS interop. It used to be called BuckleScript.
 
 [ReScript@8.3](https://www.npmjs.com/package/bs-platform/v/8.3.0) is now available for testing, you can try it via
@@ -46,7 +45,7 @@ external readFileAsUtf8Sync : string -> (_[@bs.as "utf8"]) -> string = "readFile
 
 </CodeTab>
 
-It can now be simplified as 
+It can now be simplified as
 
 <CodeTab labels={["ReScript", "Reason (Old Syntax)", "ML Syntax"]}>
 
@@ -59,18 +58,18 @@ external readFileAsUtf8Sync: (string, [@as "utf8"] _) => string =
   "readFileSync";
 ```
 ```ocaml
-external readFileAsUtf8Sync : string -> (_[@as "utf8"]) -> string = "readFileSync" 
+external readFileAsUtf8Sync : string -> (_[@as "utf8"]) -> string = "readFileSync"
 [@@val] [@@module "fs"]
 ```
 
 </CodeTab>
 
-Note almost all previous attributes with `bs.xx` can be simplified as `xx` 
+Note almost all previous attributes with `bs.xx` can be simplified as `xx`
 with the exception of the following two that don't have abbreviations:
 
 - `bs.send.pipe` : this attribute was deprecated in favor of `bs.send`; you can still use the existing one for backward compatibility.
 
-- `bs.splice` : this attribute was deprecated in favor of `bs.variadic`; you can still use the existing one for 
+- `bs.splice` : this attribute was deprecated in favor of `bs.variadic`; you can still use the existing one for
 backward compatibility.
 
 
@@ -118,13 +117,13 @@ Now user can pick up their js file extension support per module format:
     "module": "commonjs",
     "suffix": ".cjs"
   }],
-  
+
 ```
 
 ## More flexible filename support
 
-To have better integration with other [JS infrastructures](https://github.com/rescript-lang/rescript-compiler/issues/4624), 
-for example, Next.js/React Native, we allow file names like `404.res`, 
+To have better integration with other [JS infrastructures](https://github.com/rescript-lang/rescript-compiler/issues/4624),
+for example, Next.js/React Native, we allow file names like `404.res`,
 `Button.Android.res` so that it can just be picked up by those tools
 
 
@@ -156,13 +155,13 @@ let f = (u: N.t) => {
 }; /* type error */
 ```
 ```ocaml
-module N = struct 
+module N = struct
     type t = {
-        x : int 
+        x : int
     }
 end
 
-let f (u : N.t) = 
+let f (u : N.t) =
     let {x } = u in x + 1 (* type error *)
 ```
 
@@ -174,11 +173,11 @@ You will get a type error
 Error: Unbound record field x
 ```
 
-However, since the compiler already knows the type of `u`, it is capable of looking up the label `x` properly. 
-In this release, we make the original code style work out of the box without a work-around such as adding a module prefix 
+However, since the compiler already knows the type of `u`, it is capable of looking up the label `x` properly.
+In this release, we make the original code style work out of the box without a work-around such as adding a module prefix
 like `let {N.x} = ..`
 
-## Build system enhancement 
+## Build system enhancement
 
 A lot of work is put in improving the build system, we will expand on this topic in the next post!
 

--- a/_blogposts/2020-11-17-editor-support-custom-operators-and-more.mdx
+++ b/_blogposts/2020-11-17-editor-support-custom-operators-and-more.mdx
@@ -2,7 +2,6 @@
 author: maxim
 date: "2020-11-17"
 previewImg:
-category: syntax
 badge: roadmap
 title: "Editor Support, Custom Operators and More"
 description: |

--- a/_blogposts/2020-11-26-editor-support-release-1-0.mdx
+++ b/_blogposts/2020-11-26-editor-support-release-1-0.mdx
@@ -3,7 +3,6 @@ author: rescript-team
 date: "2020-11-26"
 previewImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1606399719/Reason%20Association/rescript-lang.org/editor_support_preview_mcgpfo.jpg
 articleImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1606399722/Reason%20Association/rescript-lang.org/editor_support_article_rnlmxj.jpg
-category: syntax
 badge: release
 title: "Editor Plugin for VSCode and Vim Officially Released!"
 description: |

--- a/_blogposts/2020-12-07-release-8-4.mdx
+++ b/_blogposts/2020-12-07-release-8-4.mdx
@@ -2,7 +2,6 @@
 author: hongbo
 date: "2020-12-07"
 previewImg:
-category: compiler
 badge: release
 title: ReScript 8.4
 description: |

--- a/_blogposts/2021-02-09-release-9-0.mdx
+++ b/_blogposts/2021-02-09-release-9-0.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2021-02-09" 
+date: "2021-02-09"
 previewImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1612974395/Reason%20Association/rescript-lang.org/compiler_release_9_0_szd11o.jpg
-category: compiler
 title: ReScript 9.0
 badge: release
 description: |
@@ -23,13 +22,13 @@ npm install bs-platform@9.0.1 --save-dev
 
 You can also try our new release in the [Online Playground](/try).
 
-In this post we will highlight the most notable changes. The full changelog for this release can be found [here](https://github.com/rescript-lang/rescript-compiler/blob/master/Changes.md#90). 
+In this post we will highlight the most notable changes. The full changelog for this release can be found [here](https://github.com/rescript-lang/rescript-compiler/blob/master/Changes.md#90).
 
 ## Compiler Improvements
 
 ### New External Stdlib Configuration
 
-This is a long-awaited [feature request](https://github.com/rescript-lang/rescript-compiler/pull/2171). 
+This is a long-awaited [feature request](https://github.com/rescript-lang/rescript-compiler/pull/2171).
 
 Our compiler comes with a set of stdlib modules (such as `Belt`, `Pervasives`, etc.) for core functionality. Compiled ReScript code relies on the JS runtime version of these stdlib modules.
 
@@ -38,7 +37,7 @@ In previous versions, users couldn't ship their compiled JS code without definin
 
 To fix this problem, we introduced an `external-stdlib` configuration that allows specifying a pre-compiled stdlib npm package (`@rescript/std`). More details on how to use that feature can be found in our [External Stdlib](/docs/manual/latest/build-external-stdlib) documentation.
 
-### Less Bundle Bloat when Adding ReScript 
+### Less Bundle Bloat when Adding ReScript
 
 With each release we keep a close eye on generating code that is optimized for tree-shaking. We also believe that we reached a milestone where ReScript reliably produces output that has almost no impact on our final JS bundle-sizes (this is what we call our "zero-cost" philosophy).
 
@@ -98,13 +97,13 @@ For those interested in the details, here is a representative diff resulting fro
 function is_space(param){
 - var switcher = param - 9 | 0;
 - if (switcher > 4 || switcher < 0) {
--    return switcher == 23 ; 
+-    return switcher == 23 ;
 + if (param > 13 || param < 9) {
 +    return param === 32;
   } else {
--    return switcher !== 2;     
+-    return switcher !== 2;
 +    return param != 11;
-  }    
+  }
 }
 ```
 
@@ -169,12 +168,12 @@ Here is a code example before and after the change. Note how the `user` record s
 
 ```res
 type user = {
-  age: int 
+  age: int
 }
 
 let data = {
   "user": {
-    age: 1 
+    age: 1
   }
 }
 
@@ -184,12 +183,12 @@ let age = data["user"].age
 
 ```res
 type user = {
-  age: int 
+  age: int
 }
 
 let data = {
   "user": {
-    age: 1 
+    age: 1
   }
 }
 

--- a/_blogposts/2021-03-03-rescript-association-rebranding.mdx
+++ b/_blogposts/2021-03-03-rescript-association-rebranding.mdx
@@ -1,8 +1,7 @@
 ---
 author: rescript-association
-date: "2021-03-03" 
+date: "2021-03-03"
 previewImg: "https://res.cloudinary.com/dmm9n7v9f/image/upload/v1614782716/Reason%20Association/rescript-lang.org/ReScript_Rename_Header_kf10pl.jpg"
-category: ecosystem
 title: The ReScript Association
 description: |
   After the rebranding of ReScript, its Reason Association has now followed through to become the ReScript Association.

--- a/_blogposts/archive/a-note-on-bucklescripts-future-commitments.mdx
+++ b/_blogposts/archive/a-note-on-bucklescripts-future-commitments.mdx
@@ -3,7 +3,6 @@ author: chenglou
 co-authors:
   - ryyppy
 date: "2020-07-06"
-category: compiler
 title: A Note on BuckleScript's New Syntax and Its Future Support Commitments
 description: |
   This post clarifies the goals and commitments of the BuckleScript compiler toolchain

--- a/_blogposts/archive/a-small-step-for-bucklescript.mdx
+++ b/_blogposts/archive/a-small-step-for-bucklescript.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2018-03-13" 
+date: "2018-03-13"
 previewImg:
-category: compiler
 title: A Small Step for BuckleScript...
 description: ...and a big one for the community!
 ---

--- a/_blogposts/archive/a-story-of-exception-encoding.mdx
+++ b/_blogposts/archive/a-story-of-exception-encoding.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2020-05-06 18:00" 
+date: "2020-05-06 18:00"
 previewImg:
-category: compiler
 title: New Exception Encoding in BuckleScript
 description: |
   Highlights of our newest changes to the internal representation of exceptions
@@ -15,7 +14,7 @@ We just recently made some significant improvements with our new exception encod
 
 The new encoding allows us to provide proper, clear stacktrace information whenever a Reason/OCaml exception is thrown. This is particularly important when you have some code running in production that needs to collect those stacktrace for diagnostics.
 
-What's the difference? 
+What's the difference?
 
 ```reason
 exception My_exception { x : int};
@@ -33,7 +32,7 @@ loop ();
 When we compile and run this piece of code with the old exception encoding, this is what we'd get:
 
 ```
-exn_demo$node src/exn_demo.bs.js 
+exn_demo$node src/exn_demo.bs.js
 
 /Users/hongbozhang/git/exn_demo/src/exn_demo.bs.js:11
       throw [
@@ -82,7 +81,7 @@ exception B
 
 `exception B` is just the identity block.
 
-The identity block is an array of 2 slots. The first slot is a string like "B", while the second slot is a unique integer. 
+The identity block is an array of 2 slots. The first slot is a string like "B", while the second slot is a unique integer.
 In more detail, the native array will also have a magic tag 248 attached which is not relevant for our purposes though.
 
 ## What's the new exception encoding?
@@ -129,7 +128,7 @@ Here is an example on how you'd access the exception value within a Reason `try`
 
 ```reason
 try (someJSFunctionThrowing()) {
-| Not_found => ..  // catch  reasonml exception 1 
+| Not_found => ..  // catch  reasonml exception 1
 | Invalid_argument =>  // catch  reasonml exception 2
 | Js.Exn.Error (obj) => ... // catch js exception
 }
@@ -146,6 +145,6 @@ The `obj` value in the `Js.Exn.Error` branch is an opaque type to maintain type 
 ## Bonus
 
 Now with our new exception encoding in place, a hidden feature called [extensible variant](https://caml.inria.fr/pub/docs/manual-ocaml/extensiblevariants.html) suddenly got way more interesting as well. Practically speaking, native exceptions are actually a special form of an extensible variant, so both are benefiting from the same representation changes!
- 
+
 
 Happy hacking and we would like your feedback!

--- a/_blogposts/archive/a-story-of-lazy-encoding.mdx
+++ b/_blogposts/archive/a-story-of-lazy-encoding.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2020-05-15 18:00" 
+date: "2020-05-15 18:00"
 previewImg:
-category: compiler
 title: New Lazy Encoding in BuckleScript
 description: |
   Highlights of our newest changes to the internal representation of lazy values
@@ -37,7 +36,7 @@ Js.log2 (la, lb); // logging forced values
 
 When compiled and run in `node`, the runtime representation of our lazy values will look something like:
 ```bash
-lazy_demo$node src/lazy_demo.bs.js 
+lazy_demo$node src/lazy_demo.bs.js
 [ [Function], tag: 246 ] 3 # logging the output of two lazy blocks
 Hello, lazy # lazy1, laz2 evaluated forced by pattern match, hence logging
 1 3 #logging the evaluated lazy block
@@ -97,7 +96,7 @@ console.log(la, lb);
 
 ## What changes did we make?
 
-In the native runtime environment, the encoding of lazy values is rather complicated: 
+In the native runtime environment, the encoding of lazy values is rather complicated:
 
 - It is an array, which is not friendly for debugging in JS context.
 - It has some special tags which are not meaningful, for example, magic number 246, in JS context.
@@ -105,7 +104,7 @@ In the native runtime environment, the encoding of lazy values is rather complic
 
 So in our current master branch, we drastically simplified our lazy encoding scheme to optimize for the JS runtime as much as possible:
 
-- The encoding is uniform; it is always an object of two key value pairs. One is `RE_LAZY_DONE` to mark its status, 
+- The encoding is uniform; it is always an object of two key value pairs. One is `RE_LAZY_DONE` to mark its status,
 the other is either a closure or an evaluated value.
 
 - The compiler optimization still kicks in at compile time: if it knows a lazy value is already evaluated or does not need to be evaluated, it will promote its status to be 'done'. However, unlike in a native environment, unboxing is not happening. This makes sense since the most interesting unboxing scenarios only happen during runtime and not during compile time (a scenario which is impossible in the JSVM).

--- a/_blogposts/archive/another-encoding.mdx
+++ b/_blogposts/archive/another-encoding.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2019-10-16" 
+date: "2019-10-16"
 previewImg:
-category: compiler
 title: Another way of encoding type identity for BuckleScript libraries without using big functor
 description: |
 ---
@@ -81,7 +80,7 @@ Error: This expression has type Ins2.coll
        but an expression was expected of type Ins1.coll
 ```
 
-There are some issues with such encoding: 
+There are some issues with such encoding:
 
 - From runtime point of view, `Ins1` is initialized during runtime, its
   implementation is a *big closure*, which means even if you only use on
@@ -182,8 +181,8 @@ When we mix `a0` and `a1`, we will get a type error
 File ..., line 71, characters 13-15:
 Error: This expression has type (int, S1.identity) Coll.coll
        but an expression was expected of type (int, S0.identity) Coll.coll
-       Type S1.identity is not compatible with type S0.identity 
-```       
+       Type S1.identity is not compatible with type S0.identity
+```
 
 As you read here, by using such encoding, the data structure is more
 generalized from user point of view. The generated JS code is not in a big

--- a/_blogposts/archive/arity-zero.mdx
+++ b/_blogposts/archive/arity-zero.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2018-11-13" 
+date: "2018-11-13"
 previewImg:
-category: compiler
 title: A Change of Undefined Behavior in BuckleScript 4.0.7
 description: |
 ---
@@ -82,7 +81,7 @@ let f: unit => int = [%bs.raw {|function(param) {
 }|}];
 ```
 
-Or 
+Or
 
 ```reason
 let f: (. unit) => int = [%bs.raw {|function() {

--- a/_blogposts/archive/bucklescript-8-1-new-syntax.mdx
+++ b/_blogposts/archive/bucklescript-8-1-new-syntax.mdx
@@ -2,7 +2,6 @@
 author: chenglou
 date: "2020-07-01"
 previewImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1587472539/Reason%20Association/reasonml.org/reasonml_art1_1280_zfwnyo.png
-category: syntax
 badge: release
 title: "A New Syntax for BuckleScript"
 description: |

--- a/_blogposts/archive/bucklescript-release-1-0.mdx
+++ b/_blogposts/archive/bucklescript-release-1-0.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2017-10-01" 
+date: "2017-10-01"
 previewImg:
-category: compiler
 badge: release
 title: Bloomberg announces BuckleScript 1.0
 description: |

--- a/_blogposts/archive/bucklescript-release-1-4-2.mdx
+++ b/_blogposts/archive/bucklescript-release-1-4-2.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2017-10-02" 
+date: "2017-10-02"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 1.4.2
 description: |

--- a/_blogposts/archive/bucklescript-release-1-4-3.mdx
+++ b/_blogposts/archive/bucklescript-release-1-4-3.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2017-10-03" 
+date: "2017-10-03"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 1.4.3
 description: |

--- a/_blogposts/archive/bucklescript-release-1-5-0.mdx
+++ b/_blogposts/archive/bucklescript-release-1-5-0.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2017-10-04" 
+date: "2017-10-04"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 1.5.0
 description: |

--- a/_blogposts/archive/bucklescript-release-1-5-1.mdx
+++ b/_blogposts/archive/bucklescript-release-1-5-1.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2017-10-05" 
+date: "2017-10-05"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 1.5.1
 description: |

--- a/_blogposts/archive/bucklescript-release-1-5-2.mdx
+++ b/_blogposts/archive/bucklescript-release-1-5-2.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2017-10-06" 
+date: "2017-10-06"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 1.5.2
 description: |

--- a/_blogposts/archive/bucklescript-release-1-7-0.mdx
+++ b/_blogposts/archive/bucklescript-release-1-7-0.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2017-10-07" 
+date: "2017-10-07"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 1.7.0
 description: |
@@ -39,7 +38,7 @@ let f = (g, x) => g(. x);
 ```
 
 `f` is curried function, `g` is an uncurried function due to `[@bs]` annotation.
-In Reason, the dot in `g(. x)` is equivalent to `[@bs]`. 
+In Reason, the dot in `g(. x)` is equivalent to `[@bs]`.
 
 When we evaluate the program with the `bsc` command...
 
@@ -65,7 +64,7 @@ function (`(. 'a) => 'b`) while `f` is still a curried function.
 The compiler will also yield following JS output:
 
 ```js
-function f (g,x){ 
+function f (g,x){
     return g (x)
 }
 ```

--- a/_blogposts/archive/bucklescript-release-1-7-4.mdx
+++ b/_blogposts/archive/bucklescript-release-1-7-4.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2017-10-08" 
+date: "2017-10-08"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 1.7.4
 description: |

--- a/_blogposts/archive/bucklescript-release-1-7-5.mdx
+++ b/_blogposts/archive/bucklescript-release-1-7-5.mdx
@@ -1,10 +1,9 @@
 ---
 author: hongbo
-date: "2017-10-09" 
+date: "2017-10-09"
 previewImg:
-category: compiler
 badge: release
-title: Announcing BuckleScript 1.7.5 
+title: Announcing BuckleScript 1.7.5
 description: |
 ---
 

--- a/_blogposts/archive/bucklescript-release-3-0-0.mdx
+++ b/_blogposts/archive/bucklescript-release-3-0-0.mdx
@@ -2,7 +2,6 @@
 author: hongbo
 date: "2018-04-16"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 3.0
 description: |

--- a/_blogposts/archive/bucklescript-release-3-1-0.mdx
+++ b/_blogposts/archive/bucklescript-release-3-1-0.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2018-05-21" 
+date: "2018-05-21"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 3.1
 description: |

--- a/_blogposts/archive/bucklescript-release-3-1-4.mdx
+++ b/_blogposts/archive/bucklescript-release-3-1-4.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2018-05-23" 
+date: "2018-05-23"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 3.1.4
 description: |

--- a/_blogposts/archive/bucklescript-release-4-0-0-pt1.mdx
+++ b/_blogposts/archive/bucklescript-release-4-0-0-pt1.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2018-07-17 8:00" 
+date: "2018-07-17 8:00"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 4.0 (Part One)
 description: |
@@ -44,7 +43,7 @@ results in less reliability and OOM from time to time.
 Another complexity introduced by a JS bundler is that it explodes users
 directory structure, for beginners trying to get started with bucklescript,
 installing such huge amount of directories is intimidating. In a slow network,
-this used to result in installation failure. 
+this used to result in installation failure.
 
 We understand that existing JS bundler has a huge ecosystem and it is
 invaluable in production mode, but we are exploring whether we can provide
@@ -100,7 +99,7 @@ You can try it out in `bs-platform@4.0.0`
 bsb -init test -theme react-lite
 cd test
 npm install
-npm start 
+npm start
 http-server # start a http server
 ```
 

--- a/_blogposts/archive/bucklescript-release-4-0-0-pt2.mdx
+++ b/_blogposts/archive/bucklescript-release-4-0-0-pt2.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2018-07-17 17:00" 
+date: "2018-07-17 17:00"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 4.0 (Part Two)
 description: |

--- a/_blogposts/archive/bucklescript-release-4-0-17.mdx
+++ b/_blogposts/archive/bucklescript-release-4-0-17.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2019-01-07" 
+date: "2019-01-07"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 4.0.17
 description: |

--- a/_blogposts/archive/bucklescript-release-4-0-8.mdx
+++ b/_blogposts/archive/bucklescript-release-4-0-8.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2018-12-05" 
+date: "2018-12-05"
 previewImg:
-category: compiler
 badge: release
 title: BuckleScript 4.0.8 (Part One)
 description: |
@@ -17,7 +16,7 @@ A detailed list of changes is available
 Most user-facing changes are bug fixes and small enhancements, while quite a
 lot of work has been done behind the scenes towards the more fundamental
 improvements coming down the line. This blog post refers to the BuckleScript
-runtime and some of the work we are doing to improve it. 
+runtime and some of the work we are doing to improve it.
 
 The design goal of BuckleScript is to make the runtime as small as possible.
 This runtime is divided into two parts: the C shims, and the fundamental
@@ -73,7 +72,7 @@ catching JS exceptions exposed the concrete representation of the exception
 encoding, in particular:
 
 ```ocaml
-match ... with 
+match ... with
 | OCamlException exn -> ..
 | Js.Exn.Error e -> ...
 ```
@@ -81,10 +80,10 @@ match ... with
 In this release, we introduced a function to avoid exposing such exception constructors:
 
 ```ocaml
-match ... with 
+match ... with
 | OCamlException exn -> ...
-| e -> 
-    match Js.asJsExn e with 
+| e ->
+    match Js.asJsExn e with
     | Some jserror -> ..
     | None -> ...
 ```

--- a/_blogposts/archive/bucklescript-release-5-0-1.mdx
+++ b/_blogposts/archive/bucklescript-release-5-0-1.mdx
@@ -1,14 +1,13 @@
 ---
 author: hongbo
-date: "2019-04-09" 
+date: "2019-04-09"
 previewImg:
-category: compiler
 badge: testing
 title: Announcing BuckleScript 5.0.1
 description: |
 ---
 
-## Newest Changes 
+## Newest Changes
 
 `bs-platform@5.0.1` preview is available, try `npm i -g bs-platform@beta-4.02`!
 A detailed a list of changes is available
@@ -16,7 +15,7 @@ A detailed a list of changes is available
 
 Some notable new features in this release:
 
-### React JSX v3 
+### React JSX v3
 
 The new v3 JSX ppx is now available which means zero-cost for react-bindings
 (@rickyvetter will talk about it in a separate post).

--- a/_blogposts/archive/bucklescript-release-5-0-4.mdx
+++ b/_blogposts/archive/bucklescript-release-5-0-4.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2019-04-22" 
+date: "2019-04-22"
 previewImg:
-category: compiler
 title: Architectural Changes in BuckleScript 5.0.4 and 6.0.1
 badge: release
 description: |
@@ -14,7 +13,7 @@ We are going to make releases of bs-platform@5.0.4 and bs-platform@6.0.1, this
 release mostly contains bug fixes.
 
 At the same time, we are introducing an internal change which should be fine
-for average users. 
+for average users.
 
 If you are tooling authors, here are some details: previously we ship react_jsx
 ppx as a stand-alone binary, for example, reactjs_jsx_ppx_v2.exe,

--- a/_blogposts/archive/bucklescript-release-5-0-5.mdx
+++ b/_blogposts/archive/bucklescript-release-5-0-5.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2019-06-26" 
+date: "2019-06-26"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 5.0.5 and 6.0.2
 description: |
@@ -18,7 +17,7 @@ It has some critical bug fixes that we suggest users to upgrade.
 
 Some feature enhancement is described as below:
 
-## User land C stubs polyfill 
+## User land C stubs polyfill
 
 Previously, for existing OCaml libraries which rely on some C primitives, it
 has to be patched in source level. In this release, user can provide such
@@ -36,10 +35,10 @@ global variable like this
 
 ```js
 /**
- * @param {int} x 
+ * @param {int} x
  * @param {int} y
  * @returns {int}
- * 
+ *
  */
 require('bs-platform/lib/js/caml_external_polyfill.js').register('caml_fancy_add',function(x,y){
   return + ((""+x ) + (""+y))
@@ -61,7 +60,7 @@ For example
 external f : int -> int = "" [@@bs.val]
 ```
 ```reason
-[@bs.val] external f : int => int = "" 
+[@bs.val] external f : int => int = ""
 ```
 Here the JS function name is inferred as `f` which is the same as OCaml
 function name.

--- a/_blogposts/archive/bucklescript-release-5-0.mdx
+++ b/_blogposts/archive/bucklescript-release-5-0.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2019-03-21" 
+date: "2019-03-21"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 5.0
 description: |
@@ -35,6 +34,6 @@ let f = (obj: t) => obj->x;
 ```
 
 This is the last major release which is targeting OCaml 4.02.3, in the future
-we will make major releases targeting OCaml 4.06. 
+we will make major releases targeting OCaml 4.06.
 
 Happy Hacking!

--- a/_blogposts/archive/bucklescript-release-5-1-0.mdx
+++ b/_blogposts/archive/bucklescript-release-5-1-0.mdx
@@ -1,10 +1,9 @@
 ---
 author: hongbo
-date: "2019-08-12" 
+date: "2019-08-12"
 previewImg:
-category: compiler
 badge: release
-title: Announcing BuckleScript 5.1.0 
+title: Announcing BuckleScript 5.1.0
 description: |
 ---
 
@@ -22,7 +21,7 @@ A detailed list of changes is available
 
 Some feature enhancements are described as follows:
 
-## Introducing `bsc` to public 
+## Introducing `bsc` to public
 
 `bsc` is the underlying compiler which is invoked by `bsb`. In this release we
 simplified it a bit so that it can be used directly by customers for simple
@@ -105,7 +104,7 @@ We extended the schema to support ppx with arguments:
               {
                   "type" : "array", // command with args
                   "items": {
-                      "type" : "string" 
+                      "type" : "string"
                   }
               }
           ]

--- a/_blogposts/archive/bucklescript-release-5-2-0.mdx
+++ b/_blogposts/archive/bucklescript-release-5-2-0.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2019-09-23" 
+date: "2019-09-23"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 5.2.0 / 6.2.0
 description: |
@@ -11,7 +10,7 @@ description: |
 ## New Release
 
 `bs-platform` 5.2.0/6.2.0 is released, it contains several major enhancement
-that we would like to share with you. 
+that we would like to share with you.
 
 You can install it via `npm i -g bs-platform@5.2.0`
 
@@ -21,11 +20,11 @@ OCaml has an [advanced module
 system](https://people.mpi-sws.org/~dreyer/thesis/old/thesis050405.pdf) for
 people to structure large scale applications, it supports first class module
 and higher-order module system which is unique compared to other ML-like
-languages such as F# and Haskell. 
+languages such as F# and Haskell.
 
 In previous versions, BuckleScript compiled local modules into a JS array
 whereby global modules (module produced by a file)were transformed into JS
-objects. 
+objects.
 
 When a local module is compiled into a JS array, the field name is stripped
 away, which makes debugging and JS interop difficult. To make the debugging
@@ -37,7 +36,7 @@ In this release, the compiler generates uniform representation for global
 module and local module -- idiomatic JS object, this makes OCaml's module
 system more valuable to JS target.
 
-Below is an image showing the diff in this release 
+Below is an image showing the diff in this release
 
 <img src="https://bucklescript.github.io/img/functor.png"/>
 
@@ -45,7 +44,7 @@ As you can see, the `id` module changed from an array into an JS object.
 
 ## Pattern match code generation with annotations
 
-BuckleScript aims to generate readable code. 
+BuckleScript aims to generate readable code.
 
 OCaml has a sophiscated pattern match compiler, it generates well optimized
 code, however, for complex pattern matching, the constructor name is lost on
@@ -56,7 +55,7 @@ complex pattern match.
 In this release, we made such information available to JS backend so that we
 annotate the generated JS code with its names.
 
-Below is an image showing the diff in this release 
+Below is an image showing the diff in this release
 
 <img src="https://bucklescript.github.io/img/pattern-match.png"/>
 
@@ -65,7 +64,7 @@ In the future, we will explore if we can produce such annotation in the runtime 
 ## Code generation improvement in various places
 
 We care about the generated code quality, and will always keep improving it
-regardless how good it is. 
+regardless how good it is.
 
 In this release, we improved the code generation in quite a lot of places
 including lazy evaluation, if branches and pattern match.

--- a/_blogposts/archive/bucklescript-release-6-0.mdx
+++ b/_blogposts/archive/bucklescript-release-6-0.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2019-03-31" 
+date: "2019-03-31"
 previewImg:
-category: compiler
 badge: testing
 title: Announcing BuckleScript 6.0.0-dev.1
 description: |

--- a/_blogposts/archive/bucklescript-release-7-0-2.mdx
+++ b/_blogposts/archive/bucklescript-release-7-0-2.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2019-12-20" 
+date: "2019-12-20"
 previewImg:
-category: compiler
 badge: release
 title: Announcing BuckleScript 7.0.2-dev.1
 description: |
@@ -48,7 +47,7 @@ the maximum value with less confusing error messages!
 
 The exciting thing about this feature is that we will now have more ways of
 expressing our programs in our typical type safe records and variants without
-sacrificing on runtime performance ("zero cost interop"). 
+sacrificing on runtime performance ("zero cost interop").
 
 The best way to understand this feature is by looking at the following
 examples:
@@ -115,14 +114,14 @@ to get a better idea of how the example data structure is defined.
 
 ```reason
 [@unboxed]
-type t = 
-  | Any ('a) : t; 
+type t =
+  | Any ('a) : t;
 
 let array = [|Any(3), Any("a")|];
 ```
 ```ocaml
 (* OCaml *)
-type t = 
+type t =
   | Any : 'a -> t
 [@@unboxed]
 

--- a/_blogposts/archive/bucklescript-release-7-1-0.mdx
+++ b/_blogposts/archive/bucklescript-release-7-1-0.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2020-02-04" 
+date: "2020-02-04"
 previewImg:
-category: compiler
 tags:
   - Release
 title: Announcing BuckleScript 7.1.0

--- a/_blogposts/archive/bucklescript-release-7-2.mdx
+++ b/_blogposts/archive/bucklescript-release-7-2.mdx
@@ -2,14 +2,13 @@
 author: hongbo
 date: "2020-03-12"
 previewImg:
-category: compiler
 tags:
   - Release
 title: Announcing BuckleScript 7.2
 description: |
   This release will give us some small quality of life improvements for tool
   builders, better performance, and a new let %private modifier for hiding
-  module functionality. 
+  module functionality.
 ---
 
 ## About the Release
@@ -35,7 +34,7 @@ installation time.
 
 However, with this release the installation is so fast that  we recommend
 installing it locally instead - per project - instead, as there's no additional
-cost, and it provides better isolation. 
+cost, and it provides better isolation.
 
 You can use it with a nice tool called
 [npx](https://www.npmjs.com/package/npx), for example, `npx bsb`.
@@ -55,7 +54,7 @@ In OCaml's module system, everything is public by default, the only way to hide 
 ```reason
 module A : { let b : int} = {
     let a = 3 ;
-    let b = 4 ; 
+    let b = 4 ;
 }
 
 ```
@@ -86,7 +85,7 @@ We responded to this, and after some hard work - but _without_ changing the unde
 A micro-benchmark for comparison:
 ```
 running on 7.1
-Int64.to_string: 367.788ms # super positive number 
+Int64.to_string: 367.788ms # super positive number
 Int64.to_string: 140.451ms # median number
 Int64.to_string: 375.471ms # super negative number
 

--- a/_blogposts/archive/bucklescript-release-7-3.mdx
+++ b/_blogposts/archive/bucklescript-release-7-3.mdx
@@ -3,7 +3,6 @@ author: hongbo
 date: "2020-04-13"
 previewImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1587472539/Reason%20Association/reasonml.org/reasonml_art1_1280_zfwnyo.png
 articleImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1587024325/Reason%20Association/reasonml.org/jessica-knowlden-WVC6iAZHP0k-unsplash_t86jzt.jpg
-category: compiler
 badge: release
 title: Announcing BuckleScript 7.3
 description: |
@@ -36,7 +35,7 @@ For uncurried support, we also fixed a long standing
 inference follows naturally using the new encoding.
 
 ```reason
-bar 
+bar
  -> Belt.Array.mapU((.b)=>b.foo /*no type annotation needed */)
 ```
 
@@ -56,7 +55,7 @@ enhancement.
 let log = x => Js.log(x)
 ```
 
-The generated code used to be 
+The generated code used to be
 
 ```js
 function log(x){
@@ -65,7 +64,7 @@ function log(x){
 }
 ```
 
-It's now 
+It's now
 
 ```js
 function log(x){
@@ -79,7 +78,7 @@ We have increased the readability of the generated code in several common
 places, we believe that we reached *an important milestone* that if you write
 code using features that have counterparts in JS, the generated code is
 readable. This is not a small achievement given that quite a lot of the
-compiler code base is shared between native backend and JS backend. 
+compiler code base is shared between native backend and JS backend.
 
 There are some features that are not available in JS, for example, complex
 pattern matches, the readability of those pieces of generated code will
@@ -110,7 +109,7 @@ function popUndefined(s) {
 +    s.root = x.tail;
 +    return x.head;
    }
-   
+
  }
 ```
 
@@ -216,7 +215,7 @@ Below are similar diffs benefiting from such enhancement:
      swapUnsafe(xs, i, Js_math.random_int(i, len));
    }
 -  return /* () */0;
-+  
++
  }
 ```
 

--- a/_blogposts/archive/bucklescript-release-8-1-1.mdx
+++ b/_blogposts/archive/bucklescript-release-8-1-1.mdx
@@ -1,7 +1,6 @@
 ---
 author: chenglou
 date: "2020-07-17"
-category: compiler
 badge: release
 title: "BuckleScript 8.1.1 released"
 description: New Syntax Tweaks, Formatter and Converter
@@ -30,7 +29,7 @@ We added a new experimental flag `-fmt`, which allows you to  format any `.res`/
 
 To convert any Reason or OCaml file, just pipe the output to a new `res` file: `node_modules/.bin/bsc -fmt src/Button.re > src/Button.res`
 
-Please note that this CLI flag is still experimental until we settle on the final API (e.g. we want to add support for passing additional parameters to the formatter, such as accepting stdin). 
+Please note that this CLI flag is still experimental until we settle on the final API (e.g. we want to add support for passing additional parameters to the formatter, such as accepting stdin).
 
 We are happy for feedback! Make sure to use [this forum post](https://reasonml.chat/t/the-formatter-converter-for-the-new-syntax-is-available-for-testing/2423) for general discussions, or the [new syntax](https://github.com/BuckleScript/syntax) issue trackers for bug reports.
 

--- a/_blogposts/archive/bucklescript-release-8-2.mdx
+++ b/_blogposts/archive/bucklescript-release-8-2.mdx
@@ -1,7 +1,6 @@
 ---
 author: hongbo
 date: "2020-08-03"
-category: compiler
 badge: release
 title: "BuckleScript 8.2 released"
 description: New release 8.2
@@ -9,11 +8,11 @@ description: New release 8.2
 
 ## New Release
 
-We are happy to announce BuckleScript 8.2, which comes with a great feature: string literal types. 
+We are happy to announce BuckleScript 8.2, which comes with a great feature: string literal types.
 
 This is an exciting feature so we wrote a [dedicated blog post](https://reasonml.org/blog/string-literal-types-in-reason) about it.
 
-Besides the exciting string literal types, this release continues to deliver better compilation performance. Some internal data structures underlying the compiler were tweaked. This led to an overall compiler memory usage reduction of about 40%. 
+Besides the exciting string literal types, this release continues to deliver better compilation performance. Some internal data structures underlying the compiler were tweaked. This led to an overall compiler memory usage reduction of about 40%.
 
 Thanks to the integration of Flow parser, we are able to make the JS interop [more safe and expressive](https://github.com/BuckleScript/bucklescript/issues/4463)
 

--- a/_blogposts/archive/bucklescript-roadmap-q3-4-2018.mdx
+++ b/_blogposts/archive/bucklescript-roadmap-q3-4-2018.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2018-11-19" 
+date: "2018-11-19"
 previewImg:
-category: compiler
 badge: roadmap
 title: BuckleScript Plans for the Second Half of 2018
 description: |
@@ -44,7 +43,7 @@ toolchain, we can make better use of OCaml toolchain after such upgrade.
 ### Making better use of the new compiler internals
 
 The upgrade is divided into two stage, the first stage is focused on `no
-regression` so that we can ship it. 
+regression` so that we can ship it.
 
 Afterwards, we have plans to make better use of the more info rich IR in the
 new release. Thanks to the flambda introduced after OCaml 4.03, more
@@ -58,14 +57,14 @@ representation for OCaml datatype.
 
 Another interesting direction is to see if we can encode module in a consistent
 style: as an JS dictionary for both global modules and local modules.
- 
+
 ### Improving the usability of BuckleScript toolchain
 
 BuckleScript is focused on making better use of JS ecosystem and provide
-values to ship JS code in production (produced by BuckleScript). 
+values to ship JS code in production (produced by BuckleScript).
 
 <!-- There are still bunch of things to address, most importantly -->
- 
+
 #### Making Bucklescript toolchain more lightweight
 
 Currently it is still too heavy for users to provide JS libraries from
@@ -82,4 +81,4 @@ Currently the bsb is restricted by the npm directory layout, the generated JS
 artifacts is also restricted by it, we will see if we can relocate the JS
 artifacts or provide more flexibility for users.
 
- 
+

--- a/_blogposts/archive/feature-preview-variadic.mdx
+++ b/_blogposts/archive/feature-preview-variadic.mdx
@@ -1,9 +1,8 @@
 ---
 author: hongbo
-date: "2019-03-1" 
+date: "2019-03-1"
 previewImg:
-category: compiler
-badge: preview 
+badge: preview
 title: First-class bs.variadic Support in the Next Release
 description: |
 ---

--- a/_blogposts/archive/ffi-overview.mdx
+++ b/_blogposts/archive/ffi-overview.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2019-05-21" 
+date: "2019-05-21"
 previewImg:
-category: compiler
 title: A High Level Overview of BuckleScript Interop with JS
 description: |
 ---
@@ -10,7 +9,7 @@ description: |
 ## JS Interop in BuckleScript
 
 When users start to use BuckleScript to develop applications targeting JS, they
-have to interop with various APIs provided by the JS platform. 
+have to interop with various APIs provided by the JS platform.
 
 In theory, like [Elm](https://elm-lang.org/), BuckleScript could ship a
 comprehensive library which contains what most people would like to use daily.
@@ -72,7 +71,7 @@ Here the raw extension node asks the user to list the parameters and function
 statement in raw JS syntax. The generated JS code is as follows:
 
 ```js
-function getSafe (a,b){ 
+function getSafe (a,b){
 	if (b>=0 && b < a.length) {
     	return a [b]
      }
@@ -180,7 +179,7 @@ function getDate (d){return d.getDate()};
 
 function setDate (d,v){
    d.setDate(v);
-   return 0; // ocaml representation of unit 
+   return 0; // ocaml representation of unit
 };
 
 var date = fromFloat(10000);

--- a/_blogposts/archive/generalize-uncurry.mdx
+++ b/_blogposts/archive/generalize-uncurry.mdx
@@ -2,7 +2,6 @@
 author: hongbo
 date: "2020-03-26"
 previewImg:
-category: compiler
 title: Generalized Uncurry Support in 7.3
 description: |
 ---
@@ -34,7 +33,7 @@ BuckleScript does tons of optimizations and very aggressive arity inference so t
 However, such optimization does not apply to high order functions:
 
 ```reason
-let highOrder = (f,a,b)=> f (a, b) 
+let highOrder = (f,a,b)=> f (a, b)
 // can not infer the arity of `f` since we know
 // nothing about the arity of `f`, unless
 // we do the whole program optimization
@@ -49,7 +48,7 @@ When we create bindings for high order functions in the JS world, we would like 
 
 ## Generalized uncurried calling convention in this release
 
-Before release 7.3, we had introduced uncurried calling convention, however, it has serious limitations -- uncurried functions can not be polymorphic, it does not support labels, the error 
+Before release 7.3, we had introduced uncurried calling convention, however, it has serious limitations -- uncurried functions can not be polymorphic, it does not support labels, the error
 message leaks the underlying encoding -- now all those limitations are gone!
 
 **Previously:**
@@ -60,7 +59,7 @@ message leaks the underlying encoding -- now all those limitations are gone!
 
 <img src="https://bucklescript.github.io/img/recursive-error.png"/>
 
-The error messages above are cryptic and hard to understand. And the limitation of not supporting recursive functions make uncurried support pretty weak. 
+The error messages above are cryptic and hard to understand. And the limitation of not supporting recursive functions make uncurried support pretty weak.
 
 Now those limitations are all gone, you can have polymorphic uncurried recursive functions and it support labels.
 
@@ -112,7 +111,7 @@ The new error message:
 Error: This function is a curried function where an uncurried function is expected
 ```
 
-### When arity mismatch 
+### When arity mismatch
 
 ```reason
 let add = (. x, y ) => x + y;

--- a/_blogposts/archive/loading-stdlib-in-memory.mdx
+++ b/_blogposts/archive/loading-stdlib-in-memory.mdx
@@ -1,12 +1,11 @@
 ---
 author: hongbo
-date: "2020-02-20" 
+date: "2020-02-20"
 previewImg:
-category: compiler
 title: Improving the Stdlib Loading mechanism
 description: |
   We want to give you some insights on how we will improve the way BuckleScript
-  compiles and handles its stdlib modules. 
+  compiles and handles its stdlib modules.
 ---
 
 ## Loading stdlib from memory
@@ -24,13 +23,13 @@ You can try it via `npm i bs-platform@7.2.0-dev.4`
 When the compiler compiles a module `test.ml`, the module `Test` will import
 some modules from stdlib. This is inevitable since even basic operators in
 BuckleScript, for example `(+)`, are defined in the Pervasives module, which is
-part of the stdlib. 
+part of the stdlib.
 
 Traditionally, the compiler will consult `Pervasives.cmi`, which is a binary
 artifact describing the interface of the Pervasives module and
 `Pervasives.cmj`, which is a binary artifact describing the implementation of
 the Pervasives module. `Pervasives.cm[ij]` and other modules in stdlib are
-shipped together with the compiler. 
+shipped together with the compiler.
 
 
 **This traditional mode has some consequences:**
@@ -52,7 +51,7 @@ requests](https://github.com/BuckleScript/bucklescript/issues/2772).
 
 
 In this release, we solve the problem by embedding the binary artifacts into
-the compiler directly and loading it on demand. 
+the compiler directly and loading it on demand.
 
 To make this possible, we try to make the binary data platform agnostic and as
 compact as possible to avoid size bloating. The entrance of loading cmi/cmj has
@@ -82,7 +81,7 @@ The compiler is just one relocatable file. This makes the separation between
 the compiler and generated JS artifacts easier. The remaining work is mostly to
 design a convention between compiler and stdlib version schemes.
 
-### Better compilation performance 
+### Better compilation performance
 
 A large set of files is not loaded from the file system but rather from memory
 now!
@@ -90,7 +89,7 @@ now!
 ### Fast installation and reinstallation.
 
 Depending on your network speed, the installation is reduced from 15
-seconds to 3 seconds. Reinstallation is almost a no-op now.    
+seconds to 3 seconds. Reinstallation is almost a no-op now.
 
 <!-- TODO: collect data points later -->
 
@@ -116,7 +115,7 @@ Here is the new layout:
 |
 |-- win32
 |     |-- bsb.exe
-|     |-- bsc.exe 
+|     |-- bsc.exe
 |
 |---darwin
 |     |-- bsb.exe

--- a/_blogposts/archive/overview-of-new_encoding.mdx
+++ b/_blogposts/archive/overview-of-new_encoding.mdx
@@ -1,31 +1,30 @@
 ---
 author: hongbo
-date: "2020-06-22 18:00" 
+date: "2020-06-22 18:00"
 previewImg:
-category: compiler
 title: Make generated JavaScript Inline Caching friendly using types in BuckleScript version 8
 description: |
-  Highlights of our newest changes to the internal representation 
+  Highlights of our newest changes to the internal representation
   and how they will benefit our users.
 ---
 
-In the next version of BuckleScript, we will make several major changes to tweak the data representation for various data types, 
-making them more idiomatic and debugger friendly. 
+In the next version of BuckleScript, we will make several major changes to tweak the data representation for various data types,
+making them more idiomatic and debugger friendly.
 
-Note: since V8 or other JavaScript engines are tweaked to make idiomatic JS code run fast, these changes also results in faster running code. 
+Note: since V8 or other JavaScript engines are tweaked to make idiomatic JS code run fast, these changes also results in faster running code.
 
-Another property, for a compiled language like BuckleScript, 
-is that we can reason about [IC](https://en.wikipedia.org/wiki/Inline_caching) friendliness by just looking at the type definitions locally; 
-this is very helpful for advanced users to write performance predictable JS code. 
+Another property, for a compiled language like BuckleScript,
+is that we can reason about [IC](https://en.wikipedia.org/wiki/Inline_caching) friendliness by just looking at the type definitions locally;
+this is very helpful for advanced users to write performance predictable JS code.
 
-This is a nice [introduction](https://mrale.ph/blog/2012/06/03/explaining-js-vms-in-js-inline-caches.html) to inline caching if you are unfamiliar with this topic, 
-or you can skip the section about IC and come back later when you get more familiar. 
+This is a nice [introduction](https://mrale.ph/blog/2012/06/03/explaining-js-vms-in-js-inline-caches.html) to inline caching if you are unfamiliar with this topic,
+or you can skip the section about IC and come back later when you get more familiar.
 
 Note: this article is quite dense, so  we will skip the old encoding.
 
 ## Record (stable)
 
-BuckleScript has compiled records to idiomatic JS objects since [version 7](https://bucklescript.github.io/blog/2019/11/18/whats-new-in-7). This is great for performance and debugging. 
+BuckleScript has compiled records to idiomatic JS objects since [version 7](https://bucklescript.github.io/blog/2019/11/18/whats-new-in-7). This is great for performance and debugging.
 We also support label renaming to shorten field names to save space.
 
 Take the code below for example:
@@ -67,8 +66,8 @@ function rand(param){
 }
 ```
 
-The label renaming techniques can be applied systematically using a syntactic macro; 
-in the future we may provide an advanced mode to apply it automatically. Another nice property is that 
+The label renaming techniques can be applied systematically using a syntactic macro;
+in the future we may provide an advanced mode to apply it automatically. Another nice property is that
 only the type definition needs to be adapted; other parts of code remain untouched.
 
 ### IC friendliness
@@ -97,8 +96,8 @@ var v0  = {TAG : 0/*Black*/, _0 : /*Empty*/ 0 , _1 : 3 , _2 : /*Empty */ 0};
 var v1 = {TAG : 1/*Red*/, _0 : /*Empty*/ 0 , _1 : 3 , _2 : /*Empty */ 0};
 ```
 
-As you can see, variants are divided into two categories.  
-Variants which do not have a payload are compiled into a number starting from 0, 
+As you can see, variants are divided into two categories.
+Variants which do not have a payload are compiled into a number starting from 0,
 while variants which have a payload are compiled into an object which has the first slot named `TAG` and the following slots named as `_0`, `_1` ..
 
 ### variant with inline records
@@ -119,7 +118,7 @@ The generated JS code would be:
 var empty =/*Empty*/ 0;
 var v0  = {TAG : 0/*Black*/, l: /*Empty*/ 0 , value : 3 , r: : /*Empty */ 0};
 var v1 = {TAG : 1/*Red*/, l : /*Empty*/ 0 , value : 3 , r : /*Empty */ 0};
-``` 
+```
 
 
 ### Special case when the number of variants which has payload is only 1.
@@ -127,13 +126,13 @@ var v1 = {TAG : 1/*Red*/, l : /*Empty*/ 0 , value : 3 , r : /*Empty */ 0};
 Take the types below for example:
 
 ```reasonml
-type list = 
+type list =
     | Nil
     | Cons (int , list);
 ```
 
 
-Since only one variant has a payload, the compiler does not need  add `TAG` when we destructure the data for pattern matching. 
+Since only one variant has a payload, the compiler does not need  add `TAG` when we destructure the data for pattern matching.
 Thus, the following code:
 
 ```reasonml
@@ -150,12 +149,12 @@ var u = {_0: 1, _1 : /*Nil*/ 0 }; // No TAG data.
 The `list` type is a built-in type; its type definition is similar to this :
 
 ```reasonml
-type t ('a) = 
+type t ('a) =
     | []
     | (::) ('a , t ('a))
 ```
 
-Without any customization, this would generate JS objects with indexes like `_0`, `_1`, etc. 
+Without any customization, this would generate JS objects with indexes like `_0`, `_1`, etc.
 Since lists are so pervasive, we provide some special treatment so that
 
 ```reasonml
@@ -172,7 +171,7 @@ This is a minor change; we changed the name of `_0` to `hd` and `_1` to `tl`.
 
 Types that have only one variant with a payload are in a perfect position for IC.
 
-The number of variants which does not carry payload will not affect IC, since the pattern match will do a split first. 
+The number of variants which does not carry payload will not affect IC, since the pattern match will do a split first.
 
 Types with variants that have the same number of payloads, such as the red-black-tree example above, are also in a perfect position for IC.
 
@@ -182,21 +181,21 @@ Note that you can always tweak the variant layout to make it IC friendly. For ex
 of indirection to make all variants share the same number of payloads:
 
 ```reasonml
-type t = 
+type t =
     | A0 (a0) // 1 payload
     | A1 (a1) // 1 payload
     | A2 (a2) // 1 payload
     | C0
     | C1
-    | C2 // This will not affect IC 
+    | C2 // This will not affect IC
 ```
 
 ### Variant in debug mode
 
-Note we only generate constructor names in comments for debugging.  
-When constructor names are attached to the data, it will be more useful for debugging. When debug mode is activated using `-bs-g`, 
+Note we only generate constructor names in comments for debugging.
+When constructor names are attached to the data, it will be more useful for debugging. When debug mode is activated using `-bs-g`,
 
-The generated code will be changed from below 
+The generated code will be changed from below
 ```js
 var v0  = {TAG : 0/*Black*/, _0 : /*Empty*/ 0 , _1 : 3 , _2 : /*Empty */ 0};
 ```
@@ -222,7 +221,7 @@ The field of `HASH` is the hash of name `"hello"`, while the `VAL` is the payloa
 
 ### IC friendliness
 
-Polymorphic variants are always in a perfect position for IC, the compiler can ensure all generated objects are of the same shape. 
+Polymorphic variants are always in a perfect position for IC, the compiler can ensure all generated objects are of the same shape.
 This is because the payload is not unpacked; it is always just one payload.
 
 
@@ -230,7 +229,7 @@ This is because the payload is not unpacked; it is always just one payload.
 
 In debug mode, similar to variant, we carry the name in generated code for debugging,
 
-So instead of 
+So instead of
 ```js
 var u = {HASH : MAGIC_NUMBER, VAL: 3 }
 ```
@@ -243,7 +242,7 @@ var u = {HASH : MAGIC_NUMBER, VAL: 3 , [Symbol.for("name")] : "hello"}
 
 ## Conclusion
 
-BuckleScript users will  profit from better runtime performance and a better debugging experience for various data types, such as variants, 
-exceptions, lazy values and more since version 8.0. 
+BuckleScript users will  profit from better runtime performance and a better debugging experience for various data types, such as variants,
+exceptions, lazy values and more since version 8.0.
 
 Happy Hacking!

--- a/_blogposts/archive/scalable.mdx
+++ b/_blogposts/archive/scalable.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2019-01-11" 
+date: "2019-01-11"
 previewImg:
-category: compiler
 title: In search of lightning feedback loop in a large codebase
 description: |
 ---
@@ -11,7 +10,7 @@ description: |
 
 As software developers, when we touch a codebase, we want the edit-compile
 cycle, to be as short as possible. Studies show that feedback loop less than
-1s, or 100ms will prevent devleopers getting distracted. 
+1s, or 100ms will prevent devleopers getting distracted.
 
 This seems to be possible in a small project, but as project grows to 10k
 files, or even more, 100k files in a large company like Google, Facebook, this
@@ -24,19 +23,19 @@ The edit-build cycle in BuckleScript consists of two components: the compiler
 which does type checking and code generation and the scheduler which figures
 out what to rebuild and how to do it concurrently.
 
-## The importance of compiler's cold performance 
+## The importance of compiler's cold performance
 
 In order to reduce the edit-build latency, some languages adopt an approach of
 in memory compiler + watch mode. We think this is not a scalable or reliable
-approach. 
+approach.
 
 A compiler is a complex piece of software, the chance that a compiler has
 memory leak is not low. It is not observed in real world since compiler is used
-mostly in a short-lived setting, it starts up fast and dies off quickly. 
+mostly in a short-lived setting, it starts up fast and dies off quickly.
 
 However, this is decimated when compiler is put in server mode. When we have
 10k or 100k files held in memory, it is very easy to observe OOM (out of memory
-issues). 
+issues).
 
 We figured that to deliver a scalable and reliable system, it is better to
 decouple the compiler's complexity from the scheduler. When the compiler cold
@@ -56,7 +55,7 @@ test>cat fib.ml
 let rec fib = function
   | 0 | 1 -> 1
   | n -> fib (n - 1) + fib (n - 2)
-```  
+```
 
 ```
 test>time /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-cmi -bs-cmj -c fib.ml
@@ -84,7 +83,7 @@ In a statically typed language, suppose we have two compilation units A , B,
 and B depends on A. Whenever A changes, B gets recompiled, to make it worse,
 the recompilation propogates, all dependencies of B get recompiled, which will
 result in a snowball effect. In this model, whenever we touch the non-leaf
-compilation unit, the latency would be large. 
+compilation unit, the latency would be large.
 
 The key observation here for BuckleScript is that B does not really depend on
 the last modified time of A, it depends on the intermediate output of A (e.g,
@@ -95,10 +94,10 @@ propagation as early as possible.
 
 In BuckleScript, each compilation unit is composed of two files, the
 implementation file and interface file which are compiled to intermediate
-output .cmj and .cmi separately. 
+output .cmj and .cmi separately.
 
 The interface builds are completely separate from implemetation, it does not
-depend on .cmj (implementation intermediate output) at all. 
+depend on .cmj (implementation intermediate output) at all.
 
 Suppose the interface is not changed, whenever we touch the implementation
 file, BuckleScript designs the data structure of `.cmj` in a way that the
@@ -112,7 +111,7 @@ Suppose the `.cmj` file is still changed (P = 0.05), A's dependency B would get
 recompiled. Note `B.cmi` only depends on `A.cmi`, so it will not get compiled,
 only `B.cmj` will get recompiled, its chances that `B.cmj` gets changed will be
 even lower. In practice, the probabiity of the length of propagation chain is
-more than two is less than 
+more than two is less than
 
 ```
 0.05 * 0.05 = 0.0025
@@ -177,13 +176,13 @@ even more.
 
 Our synthetic bench is borrowed from
 [OMake](http://blog.camlcity.org/blog/omake1.html) and public available
-[here](https://github.com/bucklescript/bsb-bench). 
+[here](https://github.com/bucklescript/bsb-bench).
 
 >The benchmark has these characteristics: The task is to build n^2 libraries
 >with n^2 modules each (for a given small number n), and the dependencies
 >between the modules are created in a way so that we can stress both the
 >dependency analyzer of the build utility and the ability to run commands in
->parallel. 
+>parallel.
 
 We modified the benchmark to add interface file for each implementation file.
 
@@ -197,8 +196,8 @@ Below is what we get for a cold build from scratch:
 
 | Source size | Clean build (ms) |
 |-------------|------------------|
-| 0162        |     684          | 
-| 1250        |    5,100         | 
+| 0162        |     684          |
+| 1250        |    5,100         |
 | 4802        |   24,112         |
 | 13122       |  125,248         |
 
@@ -226,7 +225,7 @@ test9>ninja -C lib/bs -v
 ninja: Entering directory `lib/bs'
 [1/2] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe    -w -30-40+6+7+27+32..39+44+45+101 -nostdlib -I '/Users/hongbozhang/git/bsb-bench/test9/node_modules/bs-platform/lib/ocaml' -color always -c -o src/dir_1_1/m_1_1_1_1.mlast -bs-syntax-only -bs-binary-ast /Users/hongbozhang/git/bsb-bench/test9/src/dir_1_1/m_1_1_1_1.ml
 [2/2] /usr/local/lib/node_modules/bs-platform/lib/bsb_helper.exe  -g 0 -MD src/dir_1_1/m_1_1_1_1.mlast
-[1/5905] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I src/dir_4_6 -I src/dir_4_1 -I src/dir_4_8 -I src/dir_6_5 -I src/dir_6_2 -I src/dir_8_3 -I src/dir_8_4 -I src/dir_2_3 -I src/dir_2_4 -I src/dir_6_3 -I src/dir_4_9 -I src/dir_6_4 -I src/dir_4_7 -I src/dir_2_5 -I src/dir_2_2 -I src/dir_8_5 -I src/dir_8_2 -I src/dir_9_9 -I src/dir_3_7 -I src/dir_1_3 -I src/dir_9_7 -I src/dir_3_9 -I src/dir_1_4 -I src/dir_7_6 -I src/dir_7_1 -I src/dir_5_5 -I src/dir_7_8 -I src/dir_5_2 -I src/dir_3_8 -I src/dir_9_6 -I src/dir_1_5 -I src/dir_9_1 -I src/dir_1_2 -I src/dir_3_6 -I src/dir_9_8 -I src/dir_3_1 -I src/dir_5_3 -I src/dir_5_4 -I src/dir_7_9 -I src/dir_7_7 -I src/dir_8_7 -I src/dir_2_9 -I src/dir_8_9 -I src/dir_2_7 -I src/dir_4_2 -I src/dir_6_8 -I src/dir_4_5 -I src/dir_6_1 -I src/dir_6_6 -I src/dir_2_1 -I src/dir_2_6 -I src/dir_8_8 -I src/dir_8_1 -I src/dir_2_8 -I src/dir_8_6 -I src/dir_6_7 -I src/dir_6_9 -I src/dir_4_4 -I src/dir_4_3 -I src/dir_7_2 -I src/dir_7_5 -I src/dir_5_8 -I src/dir_5_1 -I src/dir_5_6 -I src/dir_1_9 -I src/dir_3_4 -I src/dir_3_3 -I src/dir_9_4 -I src/dir_1_7 -I src/dir_9_3 -I src/dir_5_7 -I src/dir_7_4 -I src/dir_5_9 -I src/dir_7_3 -I src/dir_9_2 -I src/dir_1_1 -I src/dir_9_5 -I src/dir_1_6 -I src/dir_3_2 -I src/dir_1_8 -I src/dir_3_5  -w -30-40+6+7+27+32..39+44+45+101 -nostdlib -I '/Users/hongbozhang/git/bsb-bench/test9/node_modules/bs-platform/lib/ocaml' -color always -o src/dir_1_1/m_1_1_1_1.cmj -c  src/dir_1_1/m_1_1_1_1.mlast 
+[1/5905] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I src/dir_4_6 -I src/dir_4_1 -I src/dir_4_8 -I src/dir_6_5 -I src/dir_6_2 -I src/dir_8_3 -I src/dir_8_4 -I src/dir_2_3 -I src/dir_2_4 -I src/dir_6_3 -I src/dir_4_9 -I src/dir_6_4 -I src/dir_4_7 -I src/dir_2_5 -I src/dir_2_2 -I src/dir_8_5 -I src/dir_8_2 -I src/dir_9_9 -I src/dir_3_7 -I src/dir_1_3 -I src/dir_9_7 -I src/dir_3_9 -I src/dir_1_4 -I src/dir_7_6 -I src/dir_7_1 -I src/dir_5_5 -I src/dir_7_8 -I src/dir_5_2 -I src/dir_3_8 -I src/dir_9_6 -I src/dir_1_5 -I src/dir_9_1 -I src/dir_1_2 -I src/dir_3_6 -I src/dir_9_8 -I src/dir_3_1 -I src/dir_5_3 -I src/dir_5_4 -I src/dir_7_9 -I src/dir_7_7 -I src/dir_8_7 -I src/dir_2_9 -I src/dir_8_9 -I src/dir_2_7 -I src/dir_4_2 -I src/dir_6_8 -I src/dir_4_5 -I src/dir_6_1 -I src/dir_6_6 -I src/dir_2_1 -I src/dir_2_6 -I src/dir_8_8 -I src/dir_8_1 -I src/dir_2_8 -I src/dir_8_6 -I src/dir_6_7 -I src/dir_6_9 -I src/dir_4_4 -I src/dir_4_3 -I src/dir_7_2 -I src/dir_7_5 -I src/dir_5_8 -I src/dir_5_1 -I src/dir_5_6 -I src/dir_1_9 -I src/dir_3_4 -I src/dir_3_3 -I src/dir_9_4 -I src/dir_1_7 -I src/dir_9_3 -I src/dir_5_7 -I src/dir_7_4 -I src/dir_5_9 -I src/dir_7_3 -I src/dir_9_2 -I src/dir_1_1 -I src/dir_9_5 -I src/dir_1_6 -I src/dir_3_2 -I src/dir_1_8 -I src/dir_3_5  -w -30-40+6+7+27+32..39+44+45+101 -nostdlib -I '/Users/hongbozhang/git/bsb-bench/test9/node_modules/bs-platform/lib/ocaml' -color always -o src/dir_1_1/m_1_1_1_1.cmj -c  src/dir_1_1/m_1_1_1_1.mlast
 File "/Users/hongbozhang/git/bsb-bench/test9/src/dir_1_1/m_1_1_1_1.ml", line 4, characters 4-5:
 Warning 32: unused value a.
 ```
@@ -245,15 +244,15 @@ ninja: Entering directory `lib/bs'
 [1/2] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe    -w -30-40+6+7+27+32..39+44+45+101 -nostdlib -I '/Users/hongbozhang/git/bsb-bench/test9/node_modules/bs-platform/lib/ocaml' -color always -c -o src/dir_1_1/m_1_1_1_1.mliast -bs-syntax-only -bs-binary-ast /Users/hongbozhang/git/bsb-bench/test9/src/dir_1_1/m_1_1_1_1.mli
 [2/2] /usr/local/lib/node_modules/bs-platform/lib/bsb_helper.exe  -g 0 -MD src/dir_1_1/m_1_1_1_1.mliast
 [1/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-no-builtin-ppx-mli -bs-no-implicit-include  -I src/dir_4_6 -I src/dir_4_1 -I src/dir_4_8 -I src/dir_6_5 -I src/dir_6_2 -I src/dir_8_3 -I src/dir_8_4 -I src/dir_2_3 -I src/dir_2_4 -I src/dir_6_3 -I src/dir_4_9 -I src/dir_6_4 -I src/dir_4_7 -I src/dir_2_5 -I src/dir_2_2 -I src/dir_8_5 -I src/dir_8_2 -I src/dir_9_9 -I src/dir_3_7 -I src/dir_1_3 -I src/dir_9_7 -I src/dir_3_9 -I src/dir_1_4 -I src/dir_7_6 -I src/dir_7_1 -I src/dir_5_5 -I src/dir_7_8 -I src/dir_5_2 -I src/dir_3_8 -I src/dir_9_6 -I src/dir_1_5 -I src/dir_9_1 -I src/dir_1_2 -I src/dir_3_6 -I src/dir_9_8 -I src/dir_3_1 -I src/dir_5_3 -I src/dir_5_4 -I src/dir_7_9 -I src/dir_7_7 -I src/dir_8_7 -I src/dir_2_9 -I src/dir_8_9 -I src/dir_2_7 -I src/dir_4_2 -I src/dir_6_8 -I src/dir_4_5 -I src/dir_6_1 -I src/dir_6_6 -I src/dir_2_1 -I src/dir_2_6 -I src/dir_8_8 -I src/dir_8_1 -I src/dir_2_8 -I src/dir_8_6 -I src/dir_6_7 -I src/dir_6_9 -I src/dir_4_4 -I src/dir_4_3 -I src/dir_7_2 -I src/dir_7_5 -I src/dir_5_8 -I src/dir_5_1 -I src/dir_5_6 -I src/dir_1_9 -I src/dir_3_4 -I src/dir_3_3 -I src/dir_9_4 -I src/dir_1_7 -I src/dir_9_3 -I src/dir_5_7 -I src/dir_7_4 -I src/dir_5_9 -I src/dir_7_3 -I src/dir_9_2 -I src/dir_1_1 -I src/dir_9_5 -I src/dir_1_6 -I src/dir_3_2 -I src/dir_1_8 -I src/dir_3_5  -w -30-40+6+7+27+32..39+44+45+101 -nostdlib -I '/Users/hongbozhang/git/bsb-bench/test9/node_modules/bs-platform/lib/ocaml' -color always -o src/dir_1_1/m_1_1_1_1.cmi -c  src/dir_1_1/m_1_1_1_1.mliast
-[2/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ...  -color always -o src/dir_1_1/m_1_1_1_1.cmj -c  src/dir_1_1/m_1_1_1_1.mlast 
-[3/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ...  -w -30-40+6+7+27+32..39+44+45+101 -nostdlib -I '/Users/hongbozhang/git/bsb-bench/test9/node_modules/bs-platform/lib/ocaml' -color always -o src/dir_1_1/m_1_1_2_2.cmj -c  src/dir_1_1/m_1_1_2_2.mlast 
-[4/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_1.cmj -c  src/dir_1_1/m_1_1_2_1.mlast 
-[5/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_3.cmj -c  src/dir_1_1/m_1_1_2_3.mlast 
-[6/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_9.cmj -c  src/dir_1_1/m_1_1_2_9.mlast 
-[7/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_4.cmj -c  src/dir_1_1/m_1_1_2_4.mlast 
-[8/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_5.cmj -c  src/dir_1_1/m_1_1_2_5.mlast 
-[9/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_6.cmj -c  src/dir_1_1/m_1_1_2_6.mlast 
-[10/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_7.cmj -c  src/dir_1_1/m_1_1_2_7.mlast 
+[2/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ...  -color always -o src/dir_1_1/m_1_1_1_1.cmj -c  src/dir_1_1/m_1_1_1_1.mlast
+[3/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ...  -w -30-40+6+7+27+32..39+44+45+101 -nostdlib -I '/Users/hongbozhang/git/bsb-bench/test9/node_modules/bs-platform/lib/ocaml' -color always -o src/dir_1_1/m_1_1_2_2.cmj -c  src/dir_1_1/m_1_1_2_2.mlast
+[4/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_1.cmj -c  src/dir_1_1/m_1_1_2_1.mlast
+[5/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_3.cmj -c  src/dir_1_1/m_1_1_2_3.mlast
+[6/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_9.cmj -c  src/dir_1_1/m_1_1_2_9.mlast
+[7/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_4.cmj -c  src/dir_1_1/m_1_1_2_4.mlast
+[8/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_5.cmj -c  src/dir_1_1/m_1_1_2_5.mlast
+[9/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_6.cmj -c  src/dir_1_1/m_1_1_2_6.mlast
+[10/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_7.cmj -c  src/dir_1_1/m_1_1_2_7.mlast
 [11/5906] /usr/local/lib/node_modules/bs-platform/lib/bsc.exe -bs-package-name test  -bs-package-output commonjs:lib/js/src/dir_1_1 -bs-assume-has-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include   -I ... -color always -o src/dir_1_1/m_1_1_2_8.cmj -c  src/dir_1_1/m_1_1_2_8.mlast
 ```
 
@@ -275,4 +274,4 @@ too difficult to scale it to 100K files or even more. To reach such enormous
 scalability in a reliable way, we propose to have a long-lived scheduler and
 fast cold compiler. The language interface design and the design of the data
 structure for the implementation will make the longest rebuild propogation
-chain bounded by two in most cases. 
+chain bounded by two in most cases.

--- a/_blogposts/archive/state-of-reasonml-org-2020-q2-pt1.mdx
+++ b/_blogposts/archive/state-of-reasonml-org-2020-q2-pt1.mdx
@@ -3,7 +3,6 @@ author: ryyppy
 date: "2020-05-06"
 previewImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1588759056/Reason%20Association/reasonml.org/state-of-reasonml-org-q2-2020_ngvmtc.jpg
 articleImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1588599051/Reason%20Association/reasonml.org/state-of-reasonml-pt1-hero_m3n6wy.jpg
-category: docs
 title: State of reasonml.org 2020-Q2 / Pt. 1
 description: |
   A report on recent achievements in the reasonml.org project and what

--- a/_blogposts/archive/state-of-reasonml-org-2020-q2-pt2.mdx
+++ b/_blogposts/archive/state-of-reasonml-org-2020-q2-pt2.mdx
@@ -3,7 +3,6 @@ author: ryyppy
 date: "2020-05-11"
 previewImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1588759056/Reason%20Association/reasonml.org/state-of-reasonml-org-q2-2020_ngvmtc.jpg
 articleImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1588865899/Reason%20Association/reasonml.org/state-of-reasonml-2020-q2-pt2-articleimg_rmeaka.jpg
-category: docs
 title: State of reasonml.org 2020-Q2 / Pt. 2
 description: |
   A report on recent achievements in the reasonml.org project. This part is all

--- a/_blogposts/archive/state-of-reasonml-org-2020-q2-pt3.mdx
+++ b/_blogposts/archive/state-of-reasonml-org-2020-q2-pt3.mdx
@@ -2,11 +2,10 @@
 author: ryyppy
 date: "2020-05-12"
 previewImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1588759056/Reason%20Association/reasonml.org/state-of-reasonml-org-q2-2020_ngvmtc.jpg
-category: docs
 title: State of reasonml.org 2020-Q2 / Pt. 3
 description: |
   A report on recent achievements in the reasonml.org project. In this part we
-  talk about upcoming tools and features. 
+  talk about upcoming tools and features.
 ---
 
 import Image from "src/components/Image";
@@ -23,7 +22,7 @@ This article will cover some features and exciting ideas we have been working on
 As we already mentioned in our previous posts, the API documentation is currently maintained by hand, and we only offer documentation for the `Js` and `Belt` module, since they are the most relevant for BuckleScript development.
 
 This will change as soon as our [doc-tools](https://github.com/reason-association/doc-tools) are ready to be used.
- 
+
 The `doc-tools` project includes a CLI that enables us to easily run the odoc toolchain on the BuckleScript repository to generate JSON data, which will be our foundation for statically generated, good looking, and interactive doc pages within NextJS (see [SSG](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation)). The project is managed and developed by [rizo](https://github.com/rizo). You can find more information about it [here](https://www.reason-association.org/projects/doc-tools).
 
 We are aware that there is more software doing similar things, such as `redoc` or `bs-doc`, the latter acting as the driver for odoc within a BuckleScript project. Since our goal is to have a battle-tested, well-integrated and easy to use tool for odoc JSON generation, we will first start testing `doc-tools` by generating the API docs for `reasonml.org` before making it available to the broader community.
@@ -44,7 +43,7 @@ We did the ground work for our search feature and we will get into more detail a
 
 ## Playground
 
-We also invested a lot of time into thinking about the future of the Reason playground from a UX perspective. Our most important goal is to make it possible to switch BuckleScript versions on demand. We also wanted the relevant Reason version to be part of the playground bundle. 
+We also invested a lot of time into thinking about the future of the Reason playground from a UX perspective. Our most important goal is to make it possible to switch BuckleScript versions on demand. We also wanted the relevant Reason version to be part of the playground bundle.
 
 <Image src="https://res.cloudinary.com/dmm9n7v9f/image/upload/v1589268285/Reason%20Association/reasonml.org/playground-mockup_symtzn.jpg" withShadow={true} caption="UI mockup for the new playground (Desktop version)" />
 

--- a/_blogposts/archive/state-of-reasonml-org-2020-q2-pt4.mdx
+++ b/_blogposts/archive/state-of-reasonml-org-2020-q2-pt4.mdx
@@ -3,7 +3,6 @@ author: ryyppy
 date: "2020-05-15"
 previewImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1588759056/Reason%20Association/reasonml.org/state-of-reasonml-org-q2-2020_ngvmtc.jpg
 articleImg: https://res.cloudinary.com/dmm9n7v9f/image/upload/v1589395424/Reason%20Association/reasonml.org/state-of-reasonml-pt4-articleimg_jnp5mj.jpg
-category: docs
 title: State of reasonml.org 2020-Q2 / Pt. 4
 description: |
   A report on recent achievements in the reasonml.org project.
@@ -61,7 +60,7 @@ Hopefully for the future, with a unified documentation platform and blog as a ce
 
 ### Separating the Documentation for JS and Native
 
-So what about the native documentation then? `reasonml.org` reserved a spot for the Native platform, but it requires a lot of dedicated work to "Reasonify" most OCaml platform resources first. 
+So what about the native documentation then? `reasonml.org` reserved a spot for the Native platform, but it requires a lot of dedicated work to "Reasonify" most OCaml platform resources first.
 
 **Documentation would include:**
 - Reasonified OCaml manual

--- a/_blogposts/archive/string-literal-types-in-reason.mdx
+++ b/_blogposts/archive/string-literal-types-in-reason.mdx
@@ -2,10 +2,9 @@
 author: hongbo
 date: "2020-07-28 18:00"
 previewImg:
-category: compiler
 title: Introducing string literal types in BuckleScript version 8.2
 description: |
-  Highlights of our newest changes to the internal representation 
+  Highlights of our newest changes to the internal representation
   and how they will benefit our users.
 ---
 
@@ -19,7 +18,7 @@ pattern matching and can be attached to data.
 
 ## Vanilla string literal types
 
-The notation in Reason for string literal types is like this: \``hello`, which will be compiled into "hello". 
+The notation in Reason for string literal types is like this: \``hello`, which will be compiled into "hello".
 The difference is that \``hello` is given a type so that you can not mix it with other strings.
 
 Take the following code snippet as an example:
@@ -87,7 +86,7 @@ function encoding(en) {
 
 ## Declaring types for string literal types
 
-Note that all string literal types can be inferred. 
+Note that all string literal types can be inferred.
 This is very convenient for you when you are doing development. When things get more stable, it would be nice to give string literal types a name as below:
 
 ```reasonml
@@ -141,7 +140,7 @@ function classify(enc) {
 
 ## String literal types in bindings
 
-Since string literal types are just strings after type checking, you can use them to 
+Since string literal types are just strings after type checking, you can use them to
 bind to js libraries directly without any conversion, as follows:
 
 ```reasonml
@@ -161,7 +160,7 @@ external readFileSync: (string, encoding) => string = "readFileSync";
 ```
 ## String literal types attached to data
 
-Since Reason is a typed language, you can not mix data of different types in a collection. 
+Since Reason is a typed language, you can not mix data of different types in a collection.
 
 For example, you will get a type error when writing code like this: `[ 3, "3" ]`.
 
@@ -214,14 +213,14 @@ To conclude, string literal types give users a convenient way to mix data with d
 Type inference is great during development. Users can also write down the formal types for string literal types attached to data:
 
 ```reasonml
-type number_or_string = [ 
-  | `Int(int) 
+type number_or_string = [
+  | `Int(int)
   | `String(string)
 ];
 ```
 
 ## Further reading
 
-Here we only cover most daily usage of string literal types. 
-For more advanced usage, see [here](https://caml.inria.fr/pub/docs/manual-ocaml/lablexamples.html#s%3Apolymorphic-variants). 
+Here we only cover most daily usage of string literal types.
+For more advanced usage, see [here](https://caml.inria.fr/pub/docs/manual-ocaml/lablexamples.html#s%3Apolymorphic-variants).
 The type theory is almost the same, however, we adapt it to make sure it is compiled into string literals to match the JS runtime.

--- a/_blogposts/archive/union-types-in-bucklescript.mdx
+++ b/_blogposts/archive/union-types-in-bucklescript.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2020-02-07" 
+date: "2020-02-07"
 previewImg:
-category: compiler
 title: Union types in BuckleScript
 description: |
   In our our 7.1.0 release we introduced the new [@unboxed] feature for better
@@ -25,9 +24,9 @@ introduction of unboxed attributes in `7.1.0`, we can create such types as
 follows:
 
 ```ocaml
-type t = 
-    | Any : 'a  -> t 
-[@@unboxed]    
+type t =
+    | Any : 'a  -> t
+[@@unboxed]
 let a (v : a) = Any v
 let b (v : b) = Any v
 let c (v : c) = Any v
@@ -46,15 +45,15 @@ let c = (v: c) => Any(v);
 > module system, we can achieve this:
 
 ```ocaml
-module A_b_c : sig 
-  type t 
-  val a : a -> t 
-  val b : b -> t 
-  val c : c -> t   
-end= struct 
-type t = 
-    | Any : 'a  -> t 
-[@@unboxed]    
+module A_b_c : sig
+  type t
+  val a : a -> t
+  val b : b -> t
+  val c : c -> t
+end= struct
+type t =
+    | Any : 'a  -> t
+[@@unboxed]
 let a (v : a) = Any v
 let b (v : b) = Any v
 let c (v : c) = Any v
@@ -70,38 +69,38 @@ module A_b_c: {
 } = {
   [@unboxed]
   type t =
-    | Any('a): t;  
+    | Any('a): t;
   let a = (v: a) => Any(v);
   let b = (v: b) => Any(v);
   let c = (v: c) => Any(v);
 };
 ```
 <!-- Union types are useful for modeling situations when values can overlap in the types they can take on.  -->
-What happens when we need to know specifically whether we have a value of type `a`? This is a case by case issue; it depends on whether there are some intersections in the runtime encoding of `a`, `b` or `c`. For some primitive types, it is easy enough to use `Js.typeof` to tell the difference between, e.g, `number` and `string`. 
+What happens when we need to know specifically whether we have a value of type `a`? This is a case by case issue; it depends on whether there are some intersections in the runtime encoding of `a`, `b` or `c`. For some primitive types, it is easy enough to use `Js.typeof` to tell the difference between, e.g, `number` and `string`.
 
 Like [type guards in typescript](https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types), we have to trust the user knowledge to differentiate between union types. However, such user level knowledge is isolated in a single module so that we can reason about its correctness locally.
 
 Let's have a simple example, `number_or_string` first:
 
 ```ocaml
-module Number_or_string : sig 
-    type t 
-    type case = 
-        | Number of float 
+module Number_or_string : sig
+    type t
+    type case =
+        | Number of float
         | String of string
-    val number : float -> t 
-    val string : string -> t 
-    val classify : t -> case             
-end = struct 
-    type t = 
-        | Any : 'a -> t 
-    [@@unboxed]     
-    type case = 
-        | Number of float 
+    val number : float -> t
+    val string : string -> t
+    val classify : t -> case
+end = struct
+    type t =
+        | Any : 'a -> t
+    [@@unboxed]
+    type case =
+        | Number of float
         | String of string
-    let number (v : float) = Any v 
-    let string (v : string) = Any v     
-    let classify (Any v : t) : case = 
+    let number (v : float) = Any v
+    let string (v : string) = Any v
+    let classify (Any v : t) : case =
         if Js.typeof v = "number" then Number (Obj.magic v  : float)
         else String (Obj.magic v : string)
 end
@@ -135,24 +134,24 @@ module Number_or_string: {
 Note that here we use `Obj.magic` to do an unsafe type cast which relies on `Js.typeof`. In practice, people may use `instanceof`; the following is an imaginary example:
 
 ```ocaml
-module A_or_b : sig 
-    type t 
-    val a : a -> t 
-    val b : b -> t 
-    type case = 
-        | A of a 
-        | B of b 
+module A_or_b : sig
+    type t
+    val a : a -> t
+    val b : b -> t
+    type case =
+        | A of a
+        | B of b
     val classify : t -> case
 end = struct
-    type t = 
+    type t =
         | Any : 'a -> t
-    [@@unboxed]   
-    type case = 
-        | A of a 
-        | B of b 
-    let a (v : a) = Any v 
+    [@@unboxed]
+    type case =
+        | A of a
+        | B of b
+    let a (v : a) = Any v
     let b = (v : b) = Any v
-    let classify ( Any v : t)  = 
+    let classify ( Any v : t)  =
         if [%raw{|function (a) { return  a instanceof globalThis.A}|}] v then A (Obj.magic v : a)
         else B (Obj.magic b)
 end

--- a/_blogposts/archive/whats-new-in-7-pt1.mdx
+++ b/_blogposts/archive/whats-new-in-7-pt1.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2019-11-18" 
+date: "2019-11-18"
 previewImg:
-category: compiler
 badge: testing
 title: What's new in BuckleScript v7 (Part 1)
 description: |
@@ -55,7 +54,7 @@ var obj = {
   y: 2,
   z: 2
 };
-``` 
+```
 
 This new change makes record much more useful and its interaction with
 `private` type; unboxed option type will make interop with JS much nicer!

--- a/_blogposts/archive/whats-new-in-7-pt2.mdx
+++ b/_blogposts/archive/whats-new-in-7-pt2.mdx
@@ -1,8 +1,7 @@
 ---
 author: hongbo
-date: "2019-11-28" 
+date: "2019-11-28"
 previewImg:
-category: compiler
 badge: testing
 title: What's new in BuckleScript v7 (Part 2)
 description: |
@@ -44,7 +43,7 @@ function f4(param) {
 }
 ```
 
-As you can see, you can manipulate js objects using Reason pattern match syntax, the generated 
+As you can see, you can manipulate js objects using Reason pattern match syntax, the generated
 code is highly efficient, more importantly, bindings to JS will be significantly simplifie.
 
 Happy Hacking.

--- a/pages/blogpost-guide.mdx
+++ b/pages/blogpost-guide.mdx
@@ -60,9 +60,8 @@ author: hongbo
 co-authors:
   - chenglou
   - ryyppy
-date: "2017-10-01" 
+date: "2017-10-01"
 previewImg:
-category: compiler
 badge: release
 title: Bloomberg announces BuckleScript 1.0
 description: |
@@ -79,7 +78,6 @@ canonical: https://rescript-lang.org/blog/2017/10/01/announcing-1-0
   posts are ordered ascending by date.
 - `previewImg`: The image shown in the blog overview, which will also be used
   as a link preview image
-- `category` (optional): Categories allow filtering on the blog overview. Available categories are `compiler`, `syntax`, `ecosystem`, `docs`, `community`
 - `badge`: An additional badge on the blog, on top of the preview image.
   Available values are `release`, `testing`, `preview`, `roadmap`
 - `title`: The title of the article (h1 headline)
@@ -89,7 +87,7 @@ canonical: https://rescript-lang.org/blog/2017/10/01/announcing-1-0
   the original source of a post, in case it is duplicated content)
 
 > **For Maintainers:** The implementation for the frontmatter logic can be found in the
-`common/BlogFrontmatter.re` module. 
+`common/BlogFrontmatter.res` module.
 
 ### Writing Markdown Content
 

--- a/src/Blog.resi
+++ b/src/Blog.resi
@@ -19,7 +19,6 @@ type props = {
   posts: array<Post.t>,
   archived: array<Post.t>,
   malformed: array<Malformed.t>,
-  availableCategories: array<BlogFrontmatter.Category.t>,
 }
 
 let default: props => React.element

--- a/src/BlogArticle.mjs
+++ b/src/BlogArticle.mjs
@@ -137,9 +137,6 @@ function $$default(props) {
     var canonical = match.canonical;
     var description = match.description;
     var title = match.title;
-    var category = Belt_Option.map(Caml_option.null_to_opt(match.category), (function (category) {
-            return BlogFrontmatter.Category.toString(category);
-          }));
     var tmp = {
       title: title + " | ReScript Blog",
       ogImage: Belt_Option.getWithDefault(Caml_option.null_to_opt(match.previewImg), Blog.defaultPreviewImg)
@@ -152,22 +149,18 @@ function $$default(props) {
     if (tmp$2 !== undefined) {
       tmp.canonical = tmp$2;
     }
-    var tmp$3 = {
-      date: match.date,
-      author: match.author,
-      co_authors: match.co_authors,
-      title: title,
-      description: description === null ? undefined : Caml_option.some(description),
-      articleImg: Caml_option.null_to_opt(match.articleImg)
-    };
-    if (category !== undefined) {
-      tmp$3.category = category;
-    }
     content = React.createElement("div", {
           className: "w-full"
         }, React.createElement(Meta.make, tmp), React.createElement("div", {
               className: "mb-10 md:mb-20"
-            }, React.createElement(BlogArticle$BlogHeader, tmp$3)), React.createElement("div", {
+            }, React.createElement(BlogArticle$BlogHeader, {
+                  date: match.date,
+                  author: match.author,
+                  co_authors: match.co_authors,
+                  title: title,
+                  description: description === null ? undefined : Caml_option.some(description),
+                  articleImg: Caml_option.null_to_opt(match.articleImg)
+                })), React.createElement("div", {
               className: "flex justify-center"
             }, React.createElement("div", {
                   className: "max-w-740 w-full"

--- a/src/BlogArticle.res
+++ b/src/BlogArticle.res
@@ -173,12 +173,7 @@ let default = (props: props) => {
       canonical,
       articleImg,
       previewImg,
-      category,
     }) =>
-    let category =
-      Js.Null.toOption(category)->Belt.Option.map(category =>
-        category->BlogFrontmatter.Category.toString
-      )
     <div className="w-full">
       <Meta
         title={title ++ " | ReScript Blog"}
@@ -192,7 +187,6 @@ let default = (props: props) => {
           author
           co_authors
           title
-          ?category
           description={description->Js.Null.toOption}
           articleImg={articleImg->Js.Null.toOption}
         />

--- a/src/common/BlogFrontmatter.mjs
+++ b/src/common/BlogFrontmatter.mjs
@@ -48,26 +48,6 @@ var Author = {
 
 function toString(c) {
   switch (c) {
-    case /* Compiler */0 :
-        return "Compiler";
-    case /* Syntax */1 :
-        return "Syntax";
-    case /* Ecosystem */2 :
-        return "Ecosystem";
-    case /* Docs */3 :
-        return "Docs";
-    case /* Community */4 :
-        return "Community";
-    
-  }
-}
-
-var Category = {
-  toString: toString
-};
-
-function toString$1(c) {
-  switch (c) {
     case /* Release */0 :
         return "Release";
     case /* Testing */1 :
@@ -81,30 +61,8 @@ function toString$1(c) {
 }
 
 var Badge = {
-  toString: toString$1
+  toString: toString
 };
-
-function decodeCategory(str) {
-  var str$1 = str.toLowerCase();
-  switch (str$1) {
-    case "community" :
-        return /* Community */4;
-    case "compiler" :
-        return /* Compiler */0;
-    case "docs" :
-        return /* Docs */3;
-    case "ecosystem" :
-        return /* Ecosystem */2;
-    case "syntax" :
-        return /* Syntax */1;
-    default:
-      throw {
-            RE_EXN_ID: Json_decode.DecodeError,
-            _1: "Unknown category \"" + str$1 + "\"",
-            Error: new Error()
-          };
-  }
-}
 
 function decodeBadge(str) {
   var str$1 = str.toLowerCase();
@@ -172,9 +130,6 @@ function decode$1(authors, json) {
                   return Json_decode.field("articleImg", Json_decode.string, param);
                 }), json)),
       title: Json_decode.field("title", Json_decode.string, json),
-      category: Js_null.fromOption(Json_decode.optional((function (j) {
-                  return decodeCategory(Json_decode.field("category", Json_decode.string, j));
-                }), json)),
       badge: Js_null.fromOption(Json_decode.optional((function (j) {
                   return decodeBadge(Json_decode.field("badge", Json_decode.string, j));
                 }), json)),
@@ -213,9 +168,7 @@ function decode$1(authors, json) {
 
 export {
   Author ,
-  Category ,
   Badge ,
-  decodeCategory ,
   decodeBadge ,
   AuthorNotFound ,
   decodeAuthor ,

--- a/src/common/BlogFrontmatter.res
+++ b/src/common/BlogFrontmatter.res
@@ -37,24 +37,6 @@ module Author = {
   let getAllAuthors = (): array<t> => rawAuthors->Json.Decode.array(decode, _)
 }
 
-module Category = {
-  type t =
-    | Compiler
-    | Syntax
-    | Ecosystem
-    | Docs
-    | Community
-
-  let toString = (c: t): string =>
-    switch c {
-    | Compiler => "Compiler"
-    | Syntax => "Syntax"
-    | Ecosystem => "Ecosystem"
-    | Docs => "Docs"
-    | Community => "Community"
-    }
-}
-
 module Badge = {
   type t =
     | Release
@@ -78,21 +60,10 @@ type t = {
   previewImg: Js.null<string>,
   articleImg: Js.null<string>,
   title: string,
-  category: Js.null<Category.t>,
   badge: Js.null<Badge.t>,
   description: Js.null<string>,
   canonical: Js.null<string>,
 }
-
-let decodeCategory = (str: string): Category.t =>
-  switch Js.String2.toLowerCase(str) {
-  | "compiler" => Compiler
-  | "syntax" => Syntax
-  | "ecosystem" => Ecosystem
-  | "docs" => Docs
-  | "community" => Community
-  | str => raise(Json.Decode.DecodeError(j`Unknown category "$str"`))
-  }
 
 let decodeBadge = (str: string): Badge.t =>
   switch Js.String2.toLowerCase(str) {
@@ -129,9 +100,6 @@ let decode = (~authors: array<Author.t>, json: Js.Json.t): result<t, string> => 
     ->optional(field("co-authors", authorDecoder(~fieldName="co-authors", ~authors)), _)
     ->Belt.Option.getWithDefault([]),
     date: json->field("date", string, _)->DateStr.fromString,
-    category: json
-    ->optional(j => field("category", string, j)->decodeCategory, _)
-    ->Js.Null.fromOption,
     badge: json->optional(j => field("badge", string, j)->decodeBadge, _)->Js.Null.fromOption,
     previewImg: json->optional(field("previewImg", string), _)->Js.Null.fromOption,
     articleImg: json->optional(field("articleImg", string), _)->Js.Null.fromOption,


### PR DESCRIPTION
Some of the categorization of our posts aren't clear, and some would
require multiple categories. Given our pace, I don't think there's any
need to filter more finely based on sometime inaccurate categories. The
default "all" and "archived" are enough
