### PR TITLE
Reflect submodule structure in Belt docs layout

### DIFF
--- a/pages/docs/manual/latest/api/belt/hash-map-int.mdx
+++ b/pages/docs/manual/latest/api/belt/hash-map-int.mdx
@@ -1,4 +1,4 @@
-# HashMapInt
+# HashMap.Int
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/hash-map-string.mdx
+++ b/pages/docs/manual/latest/api/belt/hash-map-string.mdx
@@ -1,4 +1,4 @@
-# HashMapString
+# HashMap.String
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/hash-set-int.mdx
+++ b/pages/docs/manual/latest/api/belt/hash-set-int.mdx
@@ -1,4 +1,4 @@
-# HashSetInt
+# HashSet.Int
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/hash-set-string.mdx
+++ b/pages/docs/manual/latest/api/belt/hash-set-string.mdx
@@ -1,4 +1,4 @@
-# HashSetString
+# HashSet.String
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/map-dict.mdx
+++ b/pages/docs/manual/latest/api/belt/map-dict.mdx
@@ -1,4 +1,4 @@
-# MapDict
+# Map.Dict
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/map-int.mdx
+++ b/pages/docs/manual/latest/api/belt/map-int.mdx
@@ -1,4 +1,4 @@
-# MapInt
+# Map.Int
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/map-string.mdx
+++ b/pages/docs/manual/latest/api/belt/map-string.mdx
@@ -1,4 +1,4 @@
-# MapString
+# Map.String
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/mutable-map-int.mdx
+++ b/pages/docs/manual/latest/api/belt/mutable-map-int.mdx
@@ -1,4 +1,4 @@
-# MutableMapInt
+# MutableMap.Int
 
 ## key
 

--- a/pages/docs/manual/latest/api/belt/mutable-map-string.mdx
+++ b/pages/docs/manual/latest/api/belt/mutable-map-string.mdx
@@ -1,4 +1,4 @@
-# MutableMapString
+# MutableMap.String
 
 ## key
 

--- a/pages/docs/manual/latest/api/belt/mutable-set-int.mdx
+++ b/pages/docs/manual/latest/api/belt/mutable-set-int.mdx
@@ -1,4 +1,4 @@
-# MutableSetInt
+# MutableSet.Int
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/mutable-set-string.mdx
+++ b/pages/docs/manual/latest/api/belt/mutable-set-string.mdx
@@ -1,4 +1,4 @@
-# MutableSetString
+# MutableSet.String
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/set-dict.mdx
+++ b/pages/docs/manual/latest/api/belt/set-dict.mdx
@@ -1,4 +1,4 @@
-# SetDict
+# Set.Dict
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/set-int.mdx
+++ b/pages/docs/manual/latest/api/belt/set-int.mdx
@@ -1,4 +1,4 @@
-# SetInt
+# Set.Int
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/set-string.mdx
+++ b/pages/docs/manual/latest/api/belt/set-string.mdx
@@ -1,4 +1,4 @@
-# SetString
+# Set.String
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/sort-array-int.mdx
+++ b/pages/docs/manual/latest/api/belt/sort-array-int.mdx
@@ -1,4 +1,4 @@
-# SortArrayInt
+# SortArray.Int
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/sort-array-string.mdx
+++ b/pages/docs/manual/latest/api/belt/sort-array-string.mdx
@@ -1,4 +1,4 @@
-# SortArrayString
+# SortArray.String
 
 <Intro>
 

--- a/pages/docs/manual/latest/api/belt/sort-array.mdx
+++ b/pages/docs/manual/latest/api/belt/sort-array.mdx
@@ -1,6 +1,6 @@
 # SortArray
 
-## SortArrayInt
+## SortArray.Int
 
 ```res example
 module Int = Belt.SortArray.Int
@@ -8,7 +8,7 @@ module Int = Belt.SortArray.Int
 
 Specalized when key type is `int`, more efficient than the generic type
 
-## SortArrayString
+## SortArray.String
 
 ```res example
 module String = Belt.SortArray.String

--- a/src/layouts/BeltDocsLayout.mjs
+++ b/src/layouts/BeltDocsLayout.mjs
@@ -23,11 +23,11 @@ var setNavs = [
     href: "/docs/manual/latest/api/belt/hash-set"
   },
   {
-    name: "HashSetInt",
+    name: "HashSet.Int",
     href: "/docs/manual/latest/api/belt/hash-set-int"
   },
   {
-    name: "HashSetString",
+    name: "HashSet.String",
     href: "/docs/manual/latest/api/belt/hash-set-string"
   },
   {
@@ -35,15 +35,15 @@ var setNavs = [
     href: "/docs/manual/latest/api/belt/set"
   },
   {
-    name: "SetDict",
+    name: "Set.Dict",
     href: "/docs/manual/latest/api/belt/set-dict"
   },
   {
-    name: "SetInt",
+    name: "Set.Int",
     href: "/docs/manual/latest/api/belt/set-int"
   },
   {
-    name: "SetString",
+    name: "Set.String",
     href: "/docs/manual/latest/api/belt/set-string"
   }
 ];
@@ -54,11 +54,11 @@ var mapNavs = [
     href: "/docs/manual/latest/api/belt/hash-map"
   },
   {
-    name: "HashMapInt",
+    name: "HashMap.Int",
     href: "/docs/manual/latest/api/belt/hash-map-int"
   },
   {
-    name: "HashMapString",
+    name: "HashMap.String",
     href: "/docs/manual/latest/api/belt/hash-map-string"
   },
   {
@@ -66,15 +66,15 @@ var mapNavs = [
     href: "/docs/manual/latest/api/belt/map"
   },
   {
-    name: "MapDict",
+    name: "Map.Dict",
     href: "/docs/manual/latest/api/belt/map-dict"
   },
   {
-    name: "MapInt",
+    name: "Map.Int",
     href: "/docs/manual/latest/api/belt/map-int"
   },
   {
-    name: "MapString",
+    name: "Map.String",
     href: "/docs/manual/latest/api/belt/map-string"
   }
 ];
@@ -85,11 +85,11 @@ var mutableCollectionsNavs = [
     href: "/docs/manual/latest/api/belt/mutable-map"
   },
   {
-    name: "MutableMapInt",
+    name: "MutableMap.Int",
     href: "/docs/manual/latest/api/belt/mutable-map-int"
   },
   {
-    name: "MutableMapString",
+    name: "MutableMap.String",
     href: "/docs/manual/latest/api/belt/mutable-map-string"
   },
   {
@@ -101,11 +101,11 @@ var mutableCollectionsNavs = [
     href: "/docs/manual/latest/api/belt/mutable-set"
   },
   {
-    name: "MutableSetInt",
+    name: "MutableSet.Int",
     href: "/docs/manual/latest/api/belt/mutable-set-int"
   },
   {
-    name: "MutableSetString",
+    name: "MutableSet.String",
     href: "/docs/manual/latest/api/belt/mutable-set-string"
   },
   {
@@ -155,11 +155,11 @@ var sortNavs = [
     href: "/docs/manual/latest/api/belt/sort-array"
   },
   {
-    name: "SortArrayInt",
+    name: "SortArray.Int",
     href: "/docs/manual/latest/api/belt/sort-array-int"
   },
   {
-    name: "SortArrayString",
+    name: "SortArray.String",
     href: "/docs/manual/latest/api/belt/sort-array-string"
   }
 ];

--- a/src/layouts/BeltDocsLayout.res
+++ b/src/layouts/BeltDocsLayout.res
@@ -22,12 +22,12 @@ let setNavs = [
     open NavItem
     {name: "HashSet", href: "/docs/manual/latest/api/belt/hash-set"}
   },
-  {name: "HashSetInt", href: "/docs/manual/latest/api/belt/hash-set-int"},
-  {name: "HashSetString", href: "/docs/manual/latest/api/belt/hash-set-string"},
+  {name: "HashSet.Int", href: "/docs/manual/latest/api/belt/hash-set-int"},
+  {name: "HashSet.String", href: "/docs/manual/latest/api/belt/hash-set-string"},
   {name: "Set", href: "/docs/manual/latest/api/belt/set"},
-  {name: "SetDict", href: "/docs/manual/latest/api/belt/set-dict"},
-  {name: "SetInt", href: "/docs/manual/latest/api/belt/set-int"},
-  {name: "SetString", href: "/docs/manual/latest/api/belt/set-string"},
+  {name: "Set.Dict", href: "/docs/manual/latest/api/belt/set-dict"},
+  {name: "Set.Int", href: "/docs/manual/latest/api/belt/set-int"},
+  {name: "Set.String", href: "/docs/manual/latest/api/belt/set-string"},
 ]
 
 let mapNavs = [
@@ -35,12 +35,12 @@ let mapNavs = [
     open NavItem
     {name: "HashMap", href: "/docs/manual/latest/api/belt/hash-map"}
   },
-  {name: "HashMapInt", href: "/docs/manual/latest/api/belt/hash-map-int"},
-  {name: "HashMapString", href: "/docs/manual/latest/api/belt/hash-map-string"},
+  {name: "HashMap.Int", href: "/docs/manual/latest/api/belt/hash-map-int"},
+  {name: "HashMap.String", href: "/docs/manual/latest/api/belt/hash-map-string"},
   {name: "Map", href: "/docs/manual/latest/api/belt/map"},
-  {name: "MapDict", href: "/docs/manual/latest/api/belt/map-dict"},
-  {name: "MapInt", href: "/docs/manual/latest/api/belt/map-int"},
-  {name: "MapString", href: "/docs/manual/latest/api/belt/map-string"},
+  {name: "Map.Dict", href: "/docs/manual/latest/api/belt/map-dict"},
+  {name: "Map.Int", href: "/docs/manual/latest/api/belt/map-int"},
+  {name: "Map.String", href: "/docs/manual/latest/api/belt/map-string"},
 ]
 
 let mutableCollectionsNavs = [
@@ -48,12 +48,12 @@ let mutableCollectionsNavs = [
     open NavItem
     {name: "MutableMap", href: "/docs/manual/latest/api/belt/mutable-map"}
   },
-  {name: "MutableMapInt", href: "/docs/manual/latest/api/belt/mutable-map-int"},
-  {name: "MutableMapString", href: "/docs/manual/latest/api/belt/mutable-map-string"},
+  {name: "MutableMap.Int", href: "/docs/manual/latest/api/belt/mutable-map-int"},
+  {name: "MutableMap.String", href: "/docs/manual/latest/api/belt/mutable-map-string"},
   {name: "MutableQueue", href: "/docs/manual/latest/api/belt/mutable-queue"},
   {name: "MutableSet", href: "/docs/manual/latest/api/belt/mutable-set"},
-  {name: "MutableSetInt", href: "/docs/manual/latest/api/belt/mutable-set-int"},
-  {name: "MutableSetString", href: "/docs/manual/latest/api/belt/mutable-set-string"},
+  {name: "MutableSet.Int", href: "/docs/manual/latest/api/belt/mutable-set-int"},
+  {name: "MutableSet.String", href: "/docs/manual/latest/api/belt/mutable-set-string"},
   {name: "MutableStack", href: "/docs/manual/latest/api/belt/mutable-stack"},
 ]
 
@@ -76,8 +76,8 @@ let sortNavs = [
     open NavItem
     {name: "SortArray", href: "/docs/manual/latest/api/belt/sort-array"}
   },
-  {name: "SortArrayInt", href: "/docs/manual/latest/api/belt/sort-array-int"},
-  {name: "SortArrayString", href: "/docs/manual/latest/api/belt/sort-array-string"},
+  {name: "SortArray.Int", href: "/docs/manual/latest/api/belt/sort-array-int"},
+  {name: "SortArray.String", href: "/docs/manual/latest/api/belt/sort-array-string"},
 ]
 
 let utilityNavs = [

--- a/src/layouts/BeltDocsLayout8_0_0.mjs
+++ b/src/layouts/BeltDocsLayout8_0_0.mjs
@@ -23,11 +23,11 @@ var setNavs = [
     href: "/docs/manual/v8.0.0/api/belt/hash-set"
   },
   {
-    name: "HashSetInt",
+    name: "HashSet.Int",
     href: "/docs/manual/v8.0.0/api/belt/hash-set-int"
   },
   {
-    name: "HashSetString",
+    name: "HashSet.String",
     href: "/docs/manual/v8.0.0/api/belt/hash-set-string"
   },
   {
@@ -35,15 +35,15 @@ var setNavs = [
     href: "/docs/manual/v8.0.0/api/belt/set"
   },
   {
-    name: "SetDict",
+    name: "Set.Dict",
     href: "/docs/manual/v8.0.0/api/belt/set-dict"
   },
   {
-    name: "SetInt",
+    name: "Set.Int",
     href: "/docs/manual/v8.0.0/api/belt/set-int"
   },
   {
-    name: "SetString",
+    name: "Set.String",
     href: "/docs/manual/v8.0.0/api/belt/set-string"
   }
 ];
@@ -54,11 +54,11 @@ var mapNavs = [
     href: "/docs/manual/v8.0.0/api/belt/hash-map"
   },
   {
-    name: "HashMapInt",
+    name: "HashMap.Int",
     href: "/docs/manual/v8.0.0/api/belt/hash-map-int"
   },
   {
-    name: "HashMapString",
+    name: "HashMap.String",
     href: "/docs/manual/v8.0.0/api/belt/hash-map-string"
   },
   {
@@ -66,15 +66,15 @@ var mapNavs = [
     href: "/docs/manual/v8.0.0/api/belt/map"
   },
   {
-    name: "MapDict",
+    name: "Map.Dict",
     href: "/docs/manual/v8.0.0/api/belt/map-dict"
   },
   {
-    name: "MapInt",
+    name: "Map.Int",
     href: "/docs/manual/v8.0.0/api/belt/map-int"
   },
   {
-    name: "MapString",
+    name: "Map.String",
     href: "/docs/manual/v8.0.0/api/belt/map-string"
   }
 ];
@@ -85,11 +85,11 @@ var mutableCollectionsNavs = [
     href: "/docs/manual/v8.0.0/api/belt/mutable-map"
   },
   {
-    name: "MutableMapInt",
+    name: "MutableMap.Int",
     href: "/docs/manual/v8.0.0/api/belt/mutable-map-int"
   },
   {
-    name: "MutableMapString",
+    name: "MutableMap.String",
     href: "/docs/manual/v8.0.0/api/belt/mutable-map-string"
   },
   {
@@ -101,11 +101,11 @@ var mutableCollectionsNavs = [
     href: "/docs/manual/v8.0.0/api/belt/mutable-set"
   },
   {
-    name: "MutableSetInt",
+    name: "MutableSet.Int",
     href: "/docs/manual/v8.0.0/api/belt/mutable-set-int"
   },
   {
-    name: "MutableSetString",
+    name: "MutableSet.String",
     href: "/docs/manual/v8.0.0/api/belt/mutable-set-string"
   },
   {
@@ -155,11 +155,11 @@ var sortNavs = [
     href: "/docs/manual/v8.0.0/api/belt/sort-array"
   },
   {
-    name: "SortArrayInt",
+    name: "SortArray.Int",
     href: "/docs/manual/v8.0.0/api/belt/sort-array-int"
   },
   {
-    name: "SortArrayString",
+    name: "SortArray.String",
     href: "/docs/manual/v8.0.0/api/belt/sort-array-string"
   }
 ];

--- a/src/layouts/BeltDocsLayout8_0_0.res
+++ b/src/layouts/BeltDocsLayout8_0_0.res
@@ -22,15 +22,15 @@ let setNavs = [
     open NavItem
     {name: "HashSet", href: "/docs/manual/v8.0.0/api/belt/hash-set"}
   },
-  {name: "HashSetInt", href: "/docs/manual/v8.0.0/api/belt/hash-set-int"},
+  {name: "HashSet.Int", href: "/docs/manual/v8.0.0/api/belt/hash-set-int"},
   {
-    name: "HashSetString",
+    name: "HashSet.String",
     href: "/docs/manual/v8.0.0/api/belt/hash-set-string",
   },
   {name: "Set", href: "/docs/manual/v8.0.0/api/belt/set"},
-  {name: "SetDict", href: "/docs/manual/v8.0.0/api/belt/set-dict"},
-  {name: "SetInt", href: "/docs/manual/v8.0.0/api/belt/set-int"},
-  {name: "SetString", href: "/docs/manual/v8.0.0/api/belt/set-string"},
+  {name: "Set.Dict", href: "/docs/manual/v8.0.0/api/belt/set-dict"},
+  {name: "Set.Int", href: "/docs/manual/v8.0.0/api/belt/set-int"},
+  {name: "Set.String", href: "/docs/manual/v8.0.0/api/belt/set-string"},
 ]
 
 let mapNavs = [
@@ -38,15 +38,15 @@ let mapNavs = [
     open NavItem
     {name: "HashMap", href: "/docs/manual/v8.0.0/api/belt/hash-map"}
   },
-  {name: "HashMapInt", href: "/docs/manual/v8.0.0/api/belt/hash-map-int"},
+  {name: "HashMap.Int", href: "/docs/manual/v8.0.0/api/belt/hash-map-int"},
   {
-    name: "HashMapString",
+    name: "HashMap.String",
     href: "/docs/manual/v8.0.0/api/belt/hash-map-string",
   },
   {name: "Map", href: "/docs/manual/v8.0.0/api/belt/map"},
-  {name: "MapDict", href: "/docs/manual/v8.0.0/api/belt/map-dict"},
-  {name: "MapInt", href: "/docs/manual/v8.0.0/api/belt/map-int"},
-  {name: "MapString", href: "/docs/manual/v8.0.0/api/belt/map-string"},
+  {name: "Map.Dict", href: "/docs/manual/v8.0.0/api/belt/map-dict"},
+  {name: "Map.Int", href: "/docs/manual/v8.0.0/api/belt/map-int"},
+  {name: "Map.String", href: "/docs/manual/v8.0.0/api/belt/map-string"},
 ]
 
 let mutableCollectionsNavs = [
@@ -58,21 +58,21 @@ let mutableCollectionsNavs = [
     }
   },
   {
-    name: "MutableMapInt",
+    name: "MutableMap.Int",
     href: "/docs/manual/v8.0.0/api/belt/mutable-map-int",
   },
   {
-    name: "MutableMapString",
+    name: "MutableMap.String",
     href: "/docs/manual/v8.0.0/api/belt/mutable-map-string",
   },
   {name: "MutableQueue", href: "/docs/manual/v8.0.0/api/belt/mutable-queue"},
   {name: "MutableSet", href: "/docs/manual/v8.0.0/api/belt/mutable-set"},
   {
-    name: "MutableSetInt",
+    name: "MutableSet.Int",
     href: "/docs/manual/v8.0.0/api/belt/mutable-set-int",
   },
   {
-    name: "MutableSetString",
+    name: "MutableSet.String",
     href: "/docs/manual/v8.0.0/api/belt/mutable-set-string",
   },
   {name: "MutableStack", href: "/docs/manual/v8.0.0/api/belt/mutable-stack"},
@@ -100,9 +100,9 @@ let sortNavs = [
       href: "/docs/manual/v8.0.0/api/belt/sort-array",
     }
   },
-  {name: "SortArrayInt", href: "/docs/manual/v8.0.0/api/belt/sort-array-int"},
+  {name: "SortArray.Int", href: "/docs/manual/v8.0.0/api/belt/sort-array-int"},
   {
-    name: "SortArrayString",
+    name: "SortArray.String",
     href: "/docs/manual/v8.0.0/api/belt/sort-array-string",
   },
 ]


### PR DESCRIPTION
For clarity, `HashMapString` should be called `HashMap.String` since that is how you reference that module in ReScript. Same for other submodules.