### PR TITLE
Syntax lookup: Send pipe decorator

### DIFF
--- a/misc_docs/syntax/decorator_send.mdx
+++ b/misc_docs/syntax/decorator_send.mdx
@@ -6,22 +6,29 @@ summary: "This is the `@send` decorator."
 category: "decorators"
 ---
 
-The `@send` decorator is used to bind to a method on an object.
+The `@send` decorator is used to bind to a method on an object or array.
 
 ### Example
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
+
+// Bind to a method on an object
 type document
 @send external getElementById: (document, string) => Dom.element = "getElementById"
 @val external doc: document = "document"
-
 let el = getElementById(doc, "myId")
+
+// Bind to a method on an array
+@send external fillInPlace: (array<'a>, 'a) => array<'a> = "fill"
+let a = fillInPlace([1, 2, 3], 99)
 ```
 
 ```js
 var el = document.getElementById("myId");
+
+var a = [1, 2, 3].fill(99);
 ```
 
 </CodeTab>

--- a/misc_docs/syntax/decorator_send_pipe.mdx
+++ b/misc_docs/syntax/decorator_send_pipe.mdx
@@ -1,6 +1,6 @@
 ---
 id: "send-pipe-decorator"
-keywords: ["send", "decorator"]
+keywords: ["send", "pipe", "decorator"]
 name: "@bs.send.pipe"
 summary: "This is the `@bs.send.pipe` decorator."
 category: "decorators"

--- a/misc_docs/syntax/decorator_send_pipe.mdx
+++ b/misc_docs/syntax/decorator_send_pipe.mdx
@@ -25,7 +25,7 @@ let el = getElementById("myId", doc)
 // Bind to a method on an array
 @bs.send.pipe(: array<'a>)
 external fillInPlace: 'a => array<'a> = "fill"
-let a = fillInPlace2([1, 2, 3], 99)
+let a = fillInPlace(99, [1, 2, 3])
 ```
 
 ```js

--- a/misc_docs/syntax/decorator_send_pipe.mdx
+++ b/misc_docs/syntax/decorator_send_pipe.mdx
@@ -1,0 +1,41 @@
+---
+id: "send-pipe-decorator"
+keywords: ["send", "decorator"]
+name: "@bs.send.pipe"
+summary: "This is the `@bs.send.pipe` decorator."
+category: "decorators"
+---
+
+The `@bs.send.pipe` decorator is used to bind to a method on an object or array.
+
+> This decorator has been deprecated. Use the [@send](https://rescript-lang.org/docs/manual/latest/bind-to-js-function) decorator instead.
+
+### Example
+
+<CodeTab labels={["ReScript", "JS Output"]}>
+
+```res
+// Bind to a method on an object
+type document
+@bs.send.pipe(: document)
+external getElementById: string => Dom.element = "getElementById"
+@val external doc: document = "document"
+let el = getElementById("myId", doc)
+
+// Bind to a method on an array
+@bs.send.pipe(: array<'a>)
+external fillInPlace: 'a => array<'a> = "fill"
+let a = fillInPlace2([1, 2, 3], 99)
+```
+
+```js
+var el = document.getElementById("myId");
+
+var a = [1, 2, 3].fill(99);
+```
+
+</CodeTab>
+
+### References
+
+* [Bind to JS Function](/docs/manual/latest/bind-to-js-function)


### PR DESCRIPTION
Suggestion for #162

* Also a few tweaks to the Send decorator page
* It looks like Send pipe still needs the `bs.` prefix.

**PR should be editable, please feel free edit.**
