### PR TITLE
Type-o in the example script as rescript is a bin

### DIFF
--- a/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
+++ b/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
@@ -30,7 +30,7 @@ This is useful for per-directory convertions:
 
 ```console
 # *.rei, *.ml, *.mli,....
-for f in your-folder/**/*.re; do; node_modules/rescript convert $f && rm $f; done;
+for f in your-folder/**/*.re; do; node_modules/.bin/rescript convert $f && rm $f; done;
 ```
 
 ### Upgrade an Entire Codebase


### PR DESCRIPTION
The script is referencing node modules folder for rescript and not the bin file of rescript causing the script to fail.