### PR TITLE
Highlighted UTF-8 / unicode compatibility gotchas

### DIFF
--- a/pages/docs/manual/latest/primitive-types.mdx
+++ b/pages/docs/manual/latest/primitive-types.mdx
@@ -10,6 +10,21 @@ ReScript comes with the familiar primitive types like `string`, `int`, `float`, 
 
 <!-- TODO: doc unit -->
 
+## Unicode compatibility
+
+⚠ **NOTE:** Strings in ReScript only support unicode in UTF-8 formatted files properly when wrapped in backticks:
+
+<CodeTab labels={["ReScript", "JS Output"]}>
+
+```res example
+let wrong = "I ♥ Günther"
+let right = `I ♥ Günther`
+```
+```js
+var wrong = "I \xe2\x99\xa5 G\xc3\xbcnther";
+var right = "I ♥ Günther";
+```
+
 ## String
 
 ReScript `string`s are delimited using **double** quotes (single quotes are reserved for the character type below).

--- a/pages/docs/manual/latest/primitive-types.mdx
+++ b/pages/docs/manual/latest/primitive-types.mdx
@@ -26,6 +26,7 @@ var right = "I ♥ Günther";
 ```
 
 <CodeTab/>
+
 ## String
 
 ReScript `string`s are delimited using **double** quotes (single quotes are reserved for the character type below).

--- a/pages/docs/manual/latest/primitive-types.mdx
+++ b/pages/docs/manual/latest/primitive-types.mdx
@@ -25,6 +25,7 @@ var wrong = "I \xe2\x99\xa5 G\xc3\xbcnther";
 var right = "I ♥ Günther";
 ```
 
+<CodeTab/>
 ## String
 
 ReScript `string`s are delimited using **double** quotes (single quotes are reserved for the character type below).


### PR DESCRIPTION
I had skimmed through the docs, but when I ran into the issue with `""` strings blowing up with UTF-8 contents (`Ü`, `♥`) I had no clue what I could do about this. Gladly some helpful people on the ReasonML Discord helped out with it, but before that I had spent quite a while searching for answers on both the docs and search engines.

The docs briefly mention the issue casually in middle of a title called "String interpolation" - not great. The only mention of "utf-8" on that page takes you to a section which says `Note: Char doesn't support Unicode or UTF-8 and is therefore not recommended.` - making it seem unicode is not supported at all.

Several of the top results on search engines seem to also indicate that OCaml has no support for unicode and so ReasonML/ReScript also cannot support it.

This clear highlight at the top of the page should at least help with identifying a common critical issue which a lot of users are guaranteed to run into.