### PR TITLE
Change `React.useEffect1(fn, [])` to `React.useEffect0(fn)`

### DIFF
--- a/src/components/AnsiPre.res
+++ b/src/components/AnsiPre.res
@@ -29,14 +29,17 @@ let mapColor = (~target: colorTarget, c: Color.t): string =>
 let renderSgrString = (~key: string, sgrStr: SgrString.t): React.element => {
   let {SgrString.content: content, params} = sgrStr
 
-  let className = params->Js.Array2.map(p =>
-    switch p {
-    | Sgr.Bold => "bold"
-    | Fg(c) => mapColor(~target=Fg, c)
-    | Bg(c) => mapColor(~target=Bg, c)
-    | _ => ""
-    }
-  )->Js.Array2.joinWith(" ")
+  let className =
+    params
+    ->Js.Array2.map(p =>
+      switch p {
+      | Sgr.Bold => "bold"
+      | Fg(c) => mapColor(~target=Fg, c)
+      | Bg(c) => mapColor(~target=Bg, c)
+      | _ => ""
+      }
+    )
+    ->Js.Array2.joinWith(" ")
 
   <span key className> {React.string(content)} </span>
 }

--- a/src/components/DocSearch.res
+++ b/src/components/DocSearch.res
@@ -38,7 +38,7 @@ let make = () => {
   let inputRef = React.useRef(Js.Nullable.null)
   let (state, setState) = React.useState(_ => Inactive)
 
-  React.useEffect1(() => {
+  React.useEffect0(() => {
     switch docsearch {
     | Some(init) =>
       init({
@@ -50,7 +50,7 @@ let make = () => {
     }
 
     None
-  }, [])
+  })
 
   React.useEffect1(() => {
     let isEditableTag = el =>
@@ -142,7 +142,7 @@ let make = () => {
 module Textbox = {
   @react.component
   let make = (~id: string) => {
-    React.useEffect1(() => {
+    React.useEffect0(() => {
       switch docsearch {
       | Some(init) =>
         init({
@@ -153,7 +153,7 @@ module Textbox = {
       | None => ()
       }
       None
-    }, [])
+    })
 
     // Used for the text input
     let inputRef = React.useRef(Js.Nullable.null)

--- a/src/components/Navigation.res
+++ b/src/components/Navigation.res
@@ -469,7 +469,7 @@ let make = (~fixed=true, ~overlayState: (bool, (bool => bool) => unit)) => {
   // Client side navigation requires us to reset the collapsibles
   // whenever a route change had occurred, otherwise the collapsible
   // will stay open, even though you clicked a link
-  React.useEffect1(() => {
+  React.useEffect0(() => {
     open Next.Router.Events
     let {Next.Router.events: events} = router
 
@@ -487,7 +487,7 @@ let make = (~fixed=true, ~overlayState: (bool, (bool => bool) => unit)) => {
         events->off(#hashChangeComplete(onChangeComplete))
       },
     )
-  }, [])
+  })
 
   let fixedNav = fixed ? "fixed top-0" : "relative"
 

--- a/src/components/Navigation.res
+++ b/src/components/Navigation.res
@@ -493,7 +493,7 @@ let make = (~fixed=true, ~overlayState: (bool, (bool => bool) => unit)) => {
 
   let onStateChange = (~id, state) => {
     setCollapsibles(prev => {
-      Belt.Array.keepMap(prev, next=> {
+      Belt.Array.keepMap(prev, next => {
         if next.title === id {
           Some({...next, state: state})
         } else {

--- a/src/layouts/ApiLayout.res
+++ b/src/layouts/ApiLayout.res
@@ -81,7 +81,7 @@ let make = (
   let (isSidebarOpen, setSidebarOpen) = React.useState(_ => false)
   let toggleSidebar = () => setSidebarOpen(prev => !prev)
 
-  React.useEffect1(() => {
+  React.useEffect0(() => {
     open Next.Router.Events
     let {Next.Router.events: events} = router
 
@@ -96,7 +96,7 @@ let make = (
         events->off(#hashChangeComplete(onChangeComplete))
       },
     )
-  }, [])
+  })
 
   let preludeSection =
     <div className="flex justify-between text-fire font-medium items-baseline">

--- a/src/layouts/DocsLayout.res
+++ b/src/layouts/DocsLayout.res
@@ -66,7 +66,7 @@ let make = (
   let (isSidebarOpen, setSidebarOpen) = React.useState(_ => false)
   let toggleSidebar = () => setSidebarOpen(prev => !prev)
 
-  React.useEffect1(() => {
+  React.useEffect0(() => {
     open Next.Router.Events
     let {Next.Router.events: events} = router
 
@@ -81,7 +81,7 @@ let make = (
         events->off(#hashChangeComplete(onChangeComplete))
       },
     )
-  }, [])
+  })
 
   let preludeSection =
     <div className="flex justify-between text-fire font-medium items-baseline">

--- a/src/layouts/SidebarLayout.res
+++ b/src/layouts/SidebarLayout.res
@@ -234,7 +234,7 @@ let make = (
   let (_isSidebarOpen, setSidebarOpen) = sidebarState
   let toggleSidebar = () => setSidebarOpen(prev => !prev)
 
-  React.useEffect1(() => {
+  React.useEffect0(() => {
     open Next.Router.Events
     let {Next.Router.events: events} = router
 
@@ -249,7 +249,7 @@ let make = (
         events->off(#hashChangeComplete(onChangeComplete))
       },
     )
-  }, [])
+  })
 
   let editLinkEl = switch editHref {
   | Some(href) =>


### PR DESCRIPTION
No change in behaviour, but this aligns better with [the docs](https://rescript-lang.org/docs/react/latest/hooks-effect#effect-dependencies).