### PR TITLE
Improve documentation for `@as("str")` and `@as("0")` decorator in manual and syntax widget

### DIFF
--- a/misc_docs/syntax/decorator_as.mdx
+++ b/misc_docs/syntax/decorator_as.mdx
@@ -10,7 +10,9 @@ The `@as` decorator is commonly used on record types to alias record field names
 
 This is useful to map to JavaScript attribute names that cannot be expressed in ReScript (such as keywords).
 
-### Example
+It is also possible to map a ReScript record to a JavaScript array by passing indices to the `@as` decorator.
+
+### Examples
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
@@ -26,6 +28,26 @@ let action = {type_: "ADD_USER"}
 var action = {
   type: "ADD_USER"
 };
+```
+
+</CodeTab>
+
+<CodeTab labels={["ReScript", "JS Output"]}>
+
+```res
+type t = {
+  @as("0") foo: int,
+  @as("1") bar: string,
+}
+
+let value = {foo: 7, bar: "baz"}
+```
+
+```js
+var value = [
+  7,
+  "baz"
+];
 ```
 
 </CodeTab>

--- a/misc_docs/syntax/decorator_as.mdx
+++ b/misc_docs/syntax/decorator_as.mdx
@@ -32,5 +32,6 @@ var action = {
 
 ### References
 
+* [Bind Using ReScript Record](/docs/manual/latest/bind-to-js-object#bind-using-rescript-record)
 * [Constrain Arguments Better](/docs/manual/latest/bind-to-js-function#constrain-arguments-better)
 * [Fixed Arguments](/docs/manual/latest/bind-to-js-function#fixed-arguments)

--- a/pages/docs/manual/latest/bind-to-js-object.mdx
+++ b/pages/docs/manual/latest/bind-to-js-object.mdx
@@ -46,6 +46,28 @@ var johnName = MySchool.john.name;
 
 External is documented [here](external.md). `@module` is documented [here](import-from-export-to-js.md).
 
+If you want or need to use different field names on the ReScript and the JavaScript side, you can use the `@as` decorator:
+
+<CodeTab labels={["ReScript", "JS Output"]}>
+
+```res example
+type action = {
+  @as("type") type_: string
+}
+
+let action = {type_: "ADD_USER"}
+```
+```js
+var action = {
+  type: "ADD_USER"
+};
+```
+
+</CodeTab>
+
+This is useful to map to JavaScript attribute names that cannot be expressed in ReScript (such as keywords).
+
+
 ### Bind Using ReScript Object
 
 Alternatively, you can use [ReScript object](object.md) to model a JS object too:

--- a/pages/docs/manual/latest/bind-to-js-object.mdx
+++ b/pages/docs/manual/latest/bind-to-js-object.mdx
@@ -67,6 +67,28 @@ var action = {
 
 This is useful to map to JavaScript attribute names that cannot be expressed in ReScript (such as keywords).
 
+It is also possible to map a ReScript record to a JavaScript array by passing indices to the `@as` decorator:
+
+<CodeTab labels={["ReScript", "JS Output"]}>
+
+```res
+type t = {
+  @as("0") foo: int,
+  @as("1") bar: string,
+}
+
+let value = {foo: 7, bar: "baz"}
+```
+
+```js
+var value = [
+  7,
+  "baz"
+];
+```
+
+</CodeTab>
+
 
 ### Bind Using ReScript Object
 


### PR DESCRIPTION
Fixes #189