### PR TITLE
change vistorCount to visitorCountMsg

### DIFF
--- a/pages/docs/react/latest/components-and-props.mdx
+++ b/pages/docs/react/latest/components-and-props.mdx
@@ -66,7 +66,7 @@ let make = (~title: string, ~visitorCount: int, ~children: React.element) => {
   let visitorCountMsg = "You are visitor number: " ++ Belt.Int.toString(visitorCount);
   <div>
     <div> {React.string(title)} </div>
-    <div> {React.string(vistorCount)} </div>
+    <div> {React.string(visitorCountMsg)} </div>
     children
   </div>
 }


### PR DESCRIPTION
I was trying to build this example but got a type error.

![image](https://user-images.githubusercontent.com/55033656/123574678-8e23bf00-d78d-11eb-9dee-86be06722087.png)

I believe vistorCount should be visitorCountMsg. 

I have also run `npm test` and no tests are failing.

![image](https://user-images.githubusercontent.com/55033656/123574761-b57a8c00-d78d-11eb-8dab-e39abe7b517e.png)

The corresponding JS Output is correct to my knowledge.