### PR TITLE
docs: fix syntax problems

### DIFF
--- a/pages/docs/react/latest/beyond-jsx.mdx
+++ b/pages/docs/react/latest/beyond-jsx.mdx
@@ -61,9 +61,9 @@ module Friend = {
     ~name: string,
     ~children: 'children,
     ~key: string=?,
-    unit) => {. "name": string, "children": 'children'} = "";
+    unit) => {"name": string, "children": 'children} = "";
 
-  let make = (props: {. "name": string, "children": 'children}) => {
+  let make = (props: {"name": string, "children": 'children}) => {
     // React element creation from the original make function
   }
 }


### PR DESCRIPTION
* `'children` is a type parameter, not `'children'`.
* `{. name: string, ...}` is Reason syntax for object type declaration. I think `{. "name": string, ...}` was meant to be https://rescript-lang.org/docs/manual/latest/object#type-declaration.