### PR TITLE
Fixing the reduceWithIndex documentation

### DIFF
--- a/pages/docs/manual/latest/api/belt/array.mdx
+++ b/pages/docs/manual/latest/api/belt/array.mdx
@@ -765,7 +765,7 @@ let reduceWithIndex: (array<'a>, 'b, ('b, 'a, int) => 'b) => 'b
 
 `reduceWithIndex(xs, f)`
 
-Applies `f` to each element of `xs` from beginning to end. Function `f` has three parameters: the item from the array and an “accumulator”, which starts with a value of `init` and the index of each element. `reduceWithIndex` returns the final value of the accumulator.
+Applies `f` to each element of `xs` from beginning to end. Function `f` has three parameters: an “accumulator”, which starts with a value of `init` and the item from the array and the index of each element. `reduceWithIndex` returns the final value of the accumulator.
 
 ```res example
 Belt.Array.reduceWithIndex([1, 2, 3, 4], 0, (acc, x, i) => acc + x + i) == 16

--- a/pages/docs/manual/latest/api/belt/array.mdx
+++ b/pages/docs/manual/latest/api/belt/array.mdx
@@ -768,7 +768,7 @@ let reduceWithIndex: (array<'a>, 'b, ('b, 'a, int) => 'b) => 'b
 Applies `f` to each element of `arr` from beginning to end. Function `f` has three parameters: an "accumulator", which starts with a value of `init` and the item from the array and the index of each element. `reduceWithIndex` returns the final value of the accumulator.
 
 ```res example
-Belt.Array.reduceWithIndex([1, 2, 3, 4], 0, (acc, x, i) => acc + x + i) == 16
+Belt.Array.reduceWithIndex([1, 2, 3, 4], 0, (acc, value, i) => acc + value + i) == 16
 ```
 
 ## someU

--- a/pages/docs/manual/latest/api/belt/array.mdx
+++ b/pages/docs/manual/latest/api/belt/array.mdx
@@ -763,7 +763,7 @@ let reduceWithIndexU: (array<'a>, 'b, (. 'b, 'a, int) => 'b) => 'b
 let reduceWithIndex: (array<'a>, 'b, ('b, 'a, int) => 'b) => 'b
 ```
 
-`reduceWithIndex(xs, f)`
+`reduceWithIndex(arr, init, f)`
 
 Applies `f` to each element of `xs` from beginning to end. Function `f` has three parameters: an “accumulator”, which starts with a value of `init` and the item from the array and the index of each element. `reduceWithIndex` returns the final value of the accumulator.
 

--- a/pages/docs/manual/latest/api/belt/array.mdx
+++ b/pages/docs/manual/latest/api/belt/array.mdx
@@ -765,7 +765,7 @@ let reduceWithIndex: (array<'a>, 'b, ('b, 'a, int) => 'b) => 'b
 
 `reduceWithIndex(arr, init, f)`
 
-Applies `f` to each element of `xs` from beginning to end. Function `f` has three parameters: an “accumulator”, which starts with a value of `init` and the item from the array and the index of each element. `reduceWithIndex` returns the final value of the accumulator.
+Applies `f` to each element of `arr` from beginning to end. Function `f` has three parameters: an "accumulator", which starts with a value of `init` and the item from the array and the index of each element. `reduceWithIndex` returns the final value of the accumulator.
 
 ```res example
 Belt.Array.reduceWithIndex([1, 2, 3, 4], 0, (acc, x, i) => acc + x + i) == 16


### PR DESCRIPTION
The order of the parameters documentation was wrong, reduceWithIndex callback will receive the accumulator first, item from the array and then the index of the item