### PR TITLE
fix codeexample label overlap

### DIFF
--- a/src/components/CodeExample.res
+++ b/src/components/CodeExample.res
@@ -126,7 +126,7 @@ let make = (~highlightedLines=[], ~code: string, ~showLabel=true, ~lang="text") 
 
   let label = if showLabel {
     let label = langShortname(lang)
-    <div className="absolute right-0 px-4 pb-4 bg-gray-5 font-sans text-12 font-bold text-gray-60 ">
+    <div className="absolute right-0 px-4 pb-4 font-sans text-12 font-bold text-gray-60 ">
       {
         //RES or JS Label
         Js.String2.toUpperCase(label)->React.string


### PR DESCRIPTION
The problem is that the background from the language label is hiding part of the code example

<img width="219" alt="image" src="https://user-images.githubusercontent.com/804301/130938110-afb9eba4-083b-4025-b117-2256cd10bb98.png">

I propose making transparent the background of the label so it's not that bad

<img width="219" alt="image" src="https://user-images.githubusercontent.com/804301/130938243-40b4f456-4a65-41e4-8aa6-d191193fd44c.png">
