### PR TITLE
Fixing the reduce documentation

### DIFF
--- a/pages/docs/manual/latest/api/belt/array.mdx
+++ b/pages/docs/manual/latest/api/belt/array.mdx
@@ -701,9 +701,13 @@ let reduceU: (array<'b>, 'a, (. 'a, 'b) => 'a) => 'a
 let reduce: (array<'b>, 'a, ('a, 'b) => 'a) => 'a
 ```
 
-`reduce(xs, init, f)`
+`reduce(arr, init, f)`
 
-Applies `f` to each element of `xs` from beginning to end. Function `f` has two parameters: an “accumulator” ; which starts with a value of `init` and the item from the list. `reduce` returns the final value of the accumulator.
+Applies `f` to each element of `arr`.
+
+Function `f` has two parameters: an "accumulator" which starts with a value of `init` and the next `value` from the array. 
+
+It returns the final value of the accumulator.
 
 ```res example
 Belt.Array.reduce([2, 3, 4], 1, (a, b) => a + b) == 10

--- a/pages/docs/manual/latest/api/belt/array.mdx
+++ b/pages/docs/manual/latest/api/belt/array.mdx
@@ -703,7 +703,7 @@ let reduce: (array<'b>, 'a, ('a, 'b) => 'a) => 'a
 
 `reduce(xs, init, f)`
 
-Applies `f` to each element of `xs` from beginning to end. Function `f` has two parameters: the item from the list and an “accumulator”; which starts with a value of `init`. `reduce` returns the final value of the accumulator.
+Applies `f` to each element of `xs` from beginning to end. Function `f` has two parameters: an “accumulator” ; which starts with a value of `init` and the item from the list. `reduce` returns the final value of the accumulator.
 
 ```res example
 Belt.Array.reduce([2, 3, 4], 1, (a, b) => a + b) == 10

--- a/pages/docs/manual/latest/api/belt/array.mdx
+++ b/pages/docs/manual/latest/api/belt/array.mdx
@@ -705,7 +705,7 @@ let reduce: (array<'b>, 'a, ('a, 'b) => 'a) => 'a
 
 Applies `f` to each element of `arr`.
 
-Function `f` has two parameters: an "accumulator" which starts with a value of `init` and the next `value` from the array. 
+Function `f` has two parameters: an "accumulator" which starts with a value of `init` and the next value from the array. 
 
 It returns the final value of the accumulator.
 

--- a/pages/docs/manual/latest/api/belt/array.mdx
+++ b/pages/docs/manual/latest/api/belt/array.mdx
@@ -710,7 +710,7 @@ Function `f` has two parameters: an "accumulator" which starts with a value of `
 It returns the final value of the accumulator.
 
 ```res example
-Belt.Array.reduce([2, 3, 4], 1, (a, b) => a + b) == 10
+Belt.Array.reduce([2, 3, 4], 1, (acc, value) => acc + value) == 10
 
 Belt.Array.reduce(["a", "b", "c", "d"], "", (a, b) => a ++ b) == "abcd"
 ```


### PR DESCRIPTION
The order of the parameters documentation was wrong, reduce callback will receive the accumulator first, item from the array and then the index of the item