### PR TITLE
fix(ui): mobile navigation overlay

### DIFF
--- a/src/components/Navigation.mjs
+++ b/src/components/Navigation.mjs
@@ -641,7 +641,7 @@ function Navigation(Props) {
                           )
                         })), React.createElement("div", {
                       className: (
-                        isOverlayOpen ? "flex" : "hidden"
+                        isOverlayOpen && !isSubnavOpen ? "flex" : "hidden"
                       ) + " sm:hidden flex-col fixed top-0 left-0 h-full w-full z-50 sm:w-9/12 bg-gray-100 sm:h-auto sm:flex sm:relative sm:flex-row sm:justify-between",
                       style: {
                         minWidth: minWidth,

--- a/src/components/Navigation.res
+++ b/src/components/Navigation.res
@@ -591,7 +591,7 @@ let make = (~fixed=true, ~overlayState: (bool, (bool => bool) => unit)) => {
       <div
         style={ReactDOMStyle.make(~minWidth, ~top="4rem", ())}
         className={(
-          isOverlayOpen ? "flex" : "hidden"
+          isOverlayOpen && !isSubnavOpen ? "flex" : "hidden"
         ) ++ " sm:hidden flex-col fixed top-0 left-0 h-full w-full z-50 sm:w-9/12 bg-gray-100 sm:h-auto sm:flex sm:relative sm:flex-row sm:justify-between"}>
         <MobileNav route />
       </div>


### PR DESCRIPTION
Open Menu `...` and touch in `Docs`:

![rescript-lang org_](https://user-images.githubusercontent.com/16160544/131696171-550017e8-2896-4877-8215-5409fad169bd.png)

Now, `Docs` overlays the Menu `...`