### PR TITLE
[Fix] Correct the typo "re" to "res"

### DIFF
--- a/pages/docs/react/latest/components-and-props.mdx
+++ b/pages/docs/react/latest/components-and-props.mdx
@@ -301,7 +301,7 @@ Every ReScript component can be used in JSX. For example, if we want to use our 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-// src/App.re
+// src/App.res
 
 @react.component
 let make = () => {

--- a/pages/docs/react/latest/hooks-context.mdx
+++ b/pages/docs/react/latest/hooks-context.mdx
@@ -31,7 +31,7 @@ Accepts a `React.Context.t` (the value returned from `React.createContext`) and 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-// App.re
+// App.res
 module ThemeContext = {
   let context = React.createContext("light")
 

--- a/pages/docs/react/latest/hooks-effect.mdx
+++ b/pages/docs/react/latest/hooks-effect.mdx
@@ -88,7 +88,7 @@ As an example, let's write a counter component that updates `document.title` on 
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-// Counter.re
+// Counter.res
 module Document = {
   type t;
   @val external document: t = "document";

--- a/pages/docs/react/latest/hooks-overview.mdx
+++ b/pages/docs/react/latest/hooks-overview.mdx
@@ -27,7 +27,7 @@ Just for a quick look, here is an example of a `Counter` component that allows a
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-// Counter.re
+// Counter.res
 @react.component
 let make = () => {
   let (count, setCount) = React.useState(_ => 0);

--- a/pages/docs/react/latest/hooks-ref.mdx
+++ b/pages/docs/react/latest/hooks-ref.mdx
@@ -50,7 +50,7 @@ More infos on direct DOM manipulation can be found in the [Refs and the DOM](./r
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-// TextInputWithFocusButton.re
+// TextInputWithFocusButton.res
 
 @send external focus: Dom.element => unit = "focus"
 
@@ -98,7 +98,7 @@ Reusing the example from our [Refs and the DOM](./refs-and-the-dom#callback-refs
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-// CustomTextInput.re
+// CustomTextInput.res
 
 @send external focus: Dom.element => unit = "focus"
 

--- a/pages/docs/react/latest/refs-and-the-dom.mdx
+++ b/pages/docs/react/latest/refs-and-the-dom.mdx
@@ -187,7 +187,7 @@ The example below implements a common pattern: using the ref callback to store a
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res
-// CustomTextInput.re
+// CustomTextInput.res
 
 @send external focus: Dom.element => unit = "focus"
 


### PR DESCRIPTION
- Fix Typo comment: re => res in ReScript React section.