### PR TITLE
Syntax lookup: Fix routing

### DIFF
--- a/misc_docs/syntax/extension_raw_expression.mdx
+++ b/misc_docs/syntax/extension_raw_expression.mdx
@@ -26,7 +26,7 @@ var canUseCanvas = function canUseCanvas() {
 
 </CodeTab>
 
-See `%%raw` for embedding top level blocks of JavaScript code rather than expressions.
+See [`%%raw`](#raw-top-level-expression) for embedding top level blocks of JavaScript code rather than expressions.
 
 ### References
 

--- a/misc_docs/syntax/extension_raw_top_level_expression.mdx
+++ b/misc_docs/syntax/extension_raw_top_level_expression.mdx
@@ -48,7 +48,7 @@ import "main.css";
 
 </CodeTab>
 
-See `%raw` for embedding JavaScript expressions rather than top level blocks of code.
+See [`%raw`](#raw-expression) for embedding JavaScript expressions rather than top level blocks of code.
 
 ### References
 

--- a/misc_docs/syntax/operators_float_addition.mdx
+++ b/misc_docs/syntax/operators_float_addition.mdx
@@ -20,4 +20,4 @@ var result = 1.3 + 0.5;
 
 </CodeTab>
 
-For adding *integers* see the `+` operator.
+For adding *integers* see the [`+`](#integer-addition) operator.

--- a/misc_docs/syntax/operators_integer_addition.mdx
+++ b/misc_docs/syntax/operators_integer_addition.mdx
@@ -20,6 +20,6 @@ val result = 3;
 
 </CodeTab>
 
-For adding *floats* see the `+.` operator.
+For adding *floats* see the [`+.`](#float-addition) operator.
 
-For contatenating *strings* see the `++` operator.
+For contatenating *strings* see the [`++`](#string-concatenation) operator.

--- a/src/SyntaxLookup.res
+++ b/src/SyntaxLookup.res
@@ -155,74 +155,68 @@ type state =
   | ShowFiltered(string, array<item>) // (search, filteredItems)
   | ShowDetails(item)
 
+@val @scope("window")
+external scrollTo: (int, int) => unit = "scrollTo"
+
+let scrollToTop = () => scrollTo(0, 0)
+
+let findItemById = id => allItems->Js.Array2.find(item => item.id === id)
+
+let findItemByExactName = name => allItems->Js.Array2.find(item => item.name === name)
+
+let searchItems = value =>
+  fuse
+  ->Fuse.search(value)
+  ->Belt.Array.map(m => {
+    m["item"]
+  })
+
 @react.component
 let make = () => {
   let router = Next.Router.useRouter()
   let (state, setState) = React.useState(_ => ShowAll)
 
-  React.useEffect0(() => {
-    switch getAnchor(router.asPath) {
-    | Some(anchor) =>
-      Js.Array2.find(allItems, item =>
-        GithubSlugger.slug(item.id) === anchor
-      )->Belt.Option.forEach(item => {
-        setState(_ => ShowDetails(item))
-      })
-    | None => ()
-    }
-    None
-  })
-
-  /*
-  This effect syncs the url anchor with the currently shown final match
-  within the fuzzy finder. If there is a new match that doesn't align with
-  the current anchor, the url will be rewritten with the correct anchor.
-
-  In case a selection got removed, it will also remove the anchor from the url.
-  We don't replace on every state change, because replacing the url is expensive
- */
+  // This effect is responsible for updating the view state when the router anchor changes.
+  // This effect is triggered when:
+  // [A] The page first loads.
+  // [B] The search box is cleared.
+  // [C] The search box value exactly matches an item name.
   React.useEffect1(() => {
-    switch (state, getAnchor(router.asPath)) {
-    | (ShowDetails(item), Some(anchor)) =>
-      let slug = GithubSlugger.slug(item.id)
-
-      if slug !== anchor {
-        router->Next.Router.replace("syntax-lookup#" ++ anchor)
-      } else {
-        ()
-      }
-    | (ShowDetails(item), None) =>
-      router->Next.Router.replace("syntax-lookup#" ++ GithubSlugger.slug(item.id))
-    | (_, Some(_)) => router->Next.Router.replace("syntax-lookup")
-    | _ => ()
-    }
-    None
-  }, [state])
-
-  let onSearchValueChange = value => {
-    setState(_ =>
-      switch value {
-      | "" => ShowAll
-      | search =>
-        let filtered =
-          fuse
-          ->Fuse.search(search)
-          ->Belt.Array.map(m => {
-            m["item"]
-          })
-
-        if Js.Array.length(filtered) === 1 {
-          let item = Belt.Array.getExn(filtered, 0)
-          if item.name === value {
-            ShowDetails(item)
-          } else {
-            ShowFiltered(value, filtered)
-          }
-        } else {
-          ShowFiltered(value, filtered)
+    switch getAnchor(router.asPath) {
+    | None => setState(_ => ShowAll)
+    | Some(anchor) =>
+      switch findItemById(anchor) {
+      | None => setState(_ => ShowAll)
+      | Some(item) => {
+          setState(_ => ShowDetails(item))
+          scrollToTop()
         }
       }
-    )
+    }
+    None
+  }, [router])
+
+  // onSearchValueChange() is called when:
+  // [A] The search value changes.
+  // [B] The search is cleared.
+  // [C] One of the tags is selected.
+  //
+  // We then handle three cases:
+  // [1] Search is empty - trigger a route change, and allow the EFFECT to update the view state.
+  // [2] Search exactly matches an item - trigger a route change, and allow the EFFECT to update the view state.
+  // [3] Search does not match an item - immediately update the view state to show filtered items.
+  let onSearchValueChange = value => {
+    switch value {
+    | "" => router->Next.Router.push("/syntax-lookup")
+    | value =>
+      switch findItemByExactName(value) {
+      | None => {
+          let filtered = searchItems(value)
+          setState(_ => ShowFiltered(value, filtered))
+        }
+      | Some(item) => router->Next.Router.push("/syntax-lookup#" ++ item.id)
+      }
+    }
   }
 
   let details = switch state {
@@ -273,7 +267,7 @@ let make = () => {
         let children = Belt.Array.map(items, item => {
           let onMouseDown = evt => {
             ReactEvent.Mouse.preventDefault(evt)
-            setState(_ => ShowDetails(item))
+            onSearchValueChange(item.name)
           }
           <span className="mr-2 mb-2 cursor-pointer" onMouseDown key=item.name>
             <Tag text={item.name} />
@@ -296,7 +290,7 @@ let make = () => {
   }
 
   let onSearchClear = () => {
-    setState(_ => ShowAll)
+    onSearchValueChange("")
   }
 
   <div>


### PR DESCRIPTION
Hi @ryyppy 

As discussed, this PR is a suggestion for fixing the Syntax Lookup routing.

### Notes

[1] I've tried to stay as close to the current implementation as possible and minimise changes, with one exception ...

[2] **MAIN CHANGE**: In the current code, when the **search** changes we have an effect to update the URL. In this PR I've reversed that, so when the **URL** changes it updates the search. I've tried to comment the flow of the code, see what you think.

[3] For route changes I'm using `Next.Router.push` so we get some history. The `replace` behaviour has been removed (no longer needed due to point [2] above).

[4] I've removed the `GithubSlugger.slug(item.id)` code. If we stick to the current `id` pattern using hyphenated lowercase names then I assume it's not needed? But let me know what you think.

[5] I've added a `scrollToTop()` when the router triggers a Detail view. The only time this might feel a bit weird is when you have scrolled down the page a bit and manually type in the full name of an item.

[6] **BEHAVIOUR CHANGE**: One behaviour change compared to the current implementation. If you are on a `ShowDetails` view and then change the search box, the URL anchor is *not* cleared.

**What do you think of this direction? Do you think that continuing with the current approach of syncing the route to the search (rather than syncing the search to the route) might be worth exploring more?**

### Testing

* Navigating to `/syntax-lookup` shows the `ShowAll` view.
* Full page reload of an anchored page such as `/syntax-lookup#module-decorator` shows the `ShowDetails` view.
* Clicking a tag shows the `ShowDetails` view and sets the URL anchor
* Clearing the search box via the "x" shows the `ShowAll` view and clears the URL anchor
* Clearing the search box using the keyboard shows the `ShowAll` view and clears the URL anchor
* Entering text in the search box not matching an item shows the `ShowFiltered` view, noting that the existing URL anchor remains unchanged.
* Entering text in the search box exactly matching an item name shows the `ShowDetails` view.
* `ShowDetails` view consistently scrolls to the top.
* URL history of `ShowDetails` and `ShowAll` views are retained.
