### PR TITLE
Package Index tweaks

### DIFF
--- a/data/packages_url_resources.json
+++ b/data/packages_url_resources.json
@@ -12,12 +12,5 @@
     "keywords": ["rescript", "typescript"],
     "urlHref": "https://github.com/reason-association/genType",
     "official": true
-  },
-  {
-    "name": "re-schema-form",
-    "description": "Re-schema-form is a meta based render.",
-    "keywords": ["rescript"],
-    "urlHref": "https://github.com/jongleb/re-schema-form",
-    "official": false
   }
 ]

--- a/src/Packages.mjs
+++ b/src/Packages.mjs
@@ -48,6 +48,8 @@ function filterKeywords(keywords) {
               }));
 }
 
+var uniqueKeywords = ((keywords) => [...new Set(keywords)]);
+
 function isOfficial(res) {
   if (res.TAG !== /* Npm */0) {
     return res._0.official;
@@ -65,8 +67,7 @@ function applyNpmSearch(packages, pattern) {
     shouldSort: true,
     includeScore: true,
     threshold: 0.2,
-    location: 0,
-    distance: 30,
+    ignoreLocation: true,
     minMatchCharLength: 1,
     keys: [
       "meta.uid",
@@ -83,8 +84,7 @@ function applyUrlResourceSearch(urls, pattern) {
     shouldSort: true,
     includeScore: true,
     threshold: 0.2,
-    location: 0,
-    distance: 30,
+    ignoreLocation: true,
     minMatchCharLength: 1,
     keys: [
       "name",
@@ -516,13 +516,12 @@ function getStaticProps(_ctx) {
                       return {
                               name: pkg.name,
                               version: pkg.version,
-                              keywords: filterKeywords(pkg.keywords),
+                              keywords: uniqueKeywords(filterKeywords(pkg.keywords)),
                               description: Belt_Option.getWithDefault(pkg.description, ""),
                               repositoryHref: Js_null.fromOption(pkg.links.repository),
                               npmHref: pkg.links.npm
                             };
                     }));
-              console.log(pkges);
               var index_data_dir = Path.join(Process.cwd(), "./data");
               var urlResources = JSON.parse(Fs.readFileSync(Path.join(index_data_dir, "packages_url_resources.json"), "utf8"));
               var props = {

--- a/src/Packages.res
+++ b/src/Packages.res
@@ -67,6 +67,8 @@ module Resource = {
     })
   }
 
+  let uniqueKeywords: array<string> => array<string> = %raw(`(keywords) => [...new Set(keywords)]`)
+
   let isOfficial = (res: t) => {
     switch res {
     | Npm(pkg) =>
@@ -84,8 +86,7 @@ module Resource = {
       ~shouldSort=true,
       ~includeScore=true,
       ~threshold=0.2,
-      ~location=0,
-      ~distance=30,
+      ~ignoreLocation=true,
       ~minMatchCharLength=1,
       ~keys=["meta.uid", "name", "keywords"],
       (),
@@ -103,8 +104,7 @@ module Resource = {
       ~shouldSort=true,
       ~includeScore=true,
       ~threshold=0.2,
-      ~location=0,
-      ~distance=30,
+      ~ignoreLocation=true,
       ~minMatchCharLength=1,
       ~keys=["name", "keywords"],
       (),
@@ -529,14 +529,12 @@ let getStaticProps: Next.GetStaticProps.revalidate<props, unit> = _ctx => {
       {
         name: pkg["name"],
         version: pkg["version"],
-        keywords: Resource.filterKeywords(pkg["keywords"]),
+        keywords: Resource.filterKeywords(pkg["keywords"])->Resource.uniqueKeywords,
         description: Belt.Option.getWithDefault(pkg["description"], ""),
         repositoryHref: Js.Null.fromOption(pkg["links"]["repository"]),
         npmHref: pkg["links"]["npm"],
       }
     })
-
-    Js.log(pkges)
 
     let index_data_dir = Node.Path.join2(Node.Process.cwd(), "./data")
     let urlResources =

--- a/src/bindings/Fuse.res
+++ b/src/bindings/Fuse.res
@@ -12,6 +12,8 @@ module Options = {
     @optional
     distance: int,
     @optional
+    ignoreLocation: bool,
+    @optional
     minMatchCharLength: int,
     @optional
     keys: array<string>,


### PR DESCRIPTION
Hi @ryyppy, I noticed the [discussion about the Package Index recently](https://forum.rescript-lang.org/t/package-index-missing-stuff/2341/16) and took a quick look.

This PR contains a few tweaks that may help, see what you think.

### Main change

The current Fuse.js options for `location` and `distance` favour terms near the start of search fields, but I suspect for the Package Index the location of the term is less important. So I've set the `ignoreLocation` prop to `true` and removed `location` and `distance`.

This small tweak seems to produce reasonable search results. E.g. `zora` and `fast` are returning expected results. Plus a spot check of various terms seems to be working well.

How does it look to you?

### Other changes

[1] Remove `re-schema-form` from `packages_url_resources.json`. It looks like this package is available from npm now. Also fixes a React duplicate key error.

[2] Remove duplicates in the keywords field. It looks like at least one npm package has duplicate keywords, so this fixes a React duplicate key error.
