### PR TITLE
Make @obj example generate an object

### DIFF
--- a/misc_docs/syntax/decorator_obj.mdx
+++ b/misc_docs/syntax/decorator_obj.mdx
@@ -17,15 +17,13 @@ with properties that match the function's parameter labels.
 @obj
 external action: (~name: string, unit) => _ = ""
 
-let helloAction = action(~name="Hello")
+let helloAction = action(~name="Hello", ())
 ```
 
 ```js
-function helloAction(param) {
-  return {
-    name: "Hello",
-  }
-}
+var helloAction = {
+  name: "Hello"
+};
 ```
 
 </CodeTab>


### PR DESCRIPTION
Previously it was missing the `()` parameter and generating a function.