### PR TITLE
Updating MapString -> Map.String

### DIFF
--- a/pages/docs/manual/latest/api/belt/map-string.mdx
+++ b/pages/docs/manual/latest/api/belt/map-string.mdx
@@ -1,4 +1,4 @@
-# MapString
+# Map.String
 
 <Intro>
 


### PR DESCRIPTION
Belt.MapString was not able but Belt.Map.String did.