### PR TITLE
Fix format button hover color in playground

### DIFF
--- a/src/Playground.mjs
+++ b/src/Playground.mjs
@@ -1426,7 +1426,7 @@ function Playground$ControlPanel$Button(Props) {
   var children = Props.children;
   var onClick = Props.onClick;
   var tmp = {
-    className: "inline-block text-sky hover:cursor-pointer hover:bg-sky hover:text-white-80 rounded border active:bg-sky-70 border-sky-70 px-2 py-1 "
+    className: "inline-block text-sky hover:cursor-pointer hover:bg-sky hover:text-white-80-tr rounded border active:bg-sky-70 border-sky-70 px-2 py-1 "
   };
   if (onClick !== undefined) {
     tmp.onClick = Caml_option.valFromOption(onClick);

--- a/src/Playground.res
+++ b/src/Playground.res
@@ -1107,7 +1107,7 @@ module ControlPanel = {
     let make = (~children, ~onClick=?) =>
       <button
         ?onClick
-        className="inline-block text-sky hover:cursor-pointer hover:bg-sky hover:text-white-80 rounded border active:bg-sky-70 border-sky-70 px-2 py-1 ">
+        className="inline-block text-sky hover:cursor-pointer hover:bg-sky hover:text-white-80-tr rounded border active:bg-sky-70 border-sky-70 px-2 py-1 ">
         children
       </button>
   }


### PR DESCRIPTION
Currently text on format button in playground is not visible when we hover on it. Updated format button hover color to use `text-white-80-tr`.