### PR TITLE
Clarify note in pattern-matching-destructuring.mdx

### DIFF
--- a/pages/docs/manual/latest/pattern-matching-destructuring.mdx
+++ b/pages/docs/manual/latest/pattern-matching-destructuring.mdx
@@ -488,7 +488,7 @@ if (person1.TAG) {
 
 </CodeTab>
 
-**Note:** In ReScript version < 9.0, the `if` clause is denoted as a `when`, but will be reformatted to `if` in newer versions.
+**Note:** Rescript versions < 9.0 had a `when` clause, not an `if` clause.  Rescript 9.0 changed `when` to `if`.  (`when` may still work, but is deprecated.)
 
 ### Match on Exceptions
 


### PR DESCRIPTION
Clarify the note regarding `when` clauses versus `if` clauses regarding ReScript 9.0.

I found the old wording to be confusing, so I tried to improve it.  Please let me know if you want an explanation of what exactly I found to be confusing.