### PR TITLE
installation page updated

### DIFF
--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,1 @@
+[0204/141126.005:ERROR:registration_protocol_win.cc(102)] CreateFile: 지정된 파일을 찾을 수 없습니다. (0x2)

--- a/pages/docs/manual/latest/installation.mdx
+++ b/pages/docs/manual/latest/installation.mdx
@@ -30,9 +30,14 @@ During development, instead of running `npm run build` each time to compile, use
 If you already have a JavaScript project into which you'd like to add ReScript:
 
 - Install ReScript locally as a [devDependency](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file):
-  ```sh
+  ```shhttps://github.com/coleea/rescript-lang.org
   npm install rescript --save-dev 
   ```
+  
+  If you use M1-based Mac Device, error might be occur. If so, try installing `npm@6.14` via `npm i -g npm@6.14`, then try again `npm install rescript --save-dev`.
+   
+
+
 - Create a ReScript build configuration at the root:
   ```json
   {


### PR DESCRIPTION
hello.

First, this is my first PR ever. So some procedural error might exist.

I use M1 mac mini. Yesterday I tried to install rescript using `npm i -g rescript`. but failed because of errors.

I searched for internet and I found many people failed to install rescript on `M1 mac device`.

As I know, the best solution for this is downgrading npm version to 6.14. It seems like that npm version `8.x` triggers installation error.

My conclusion is that the installation guide page `https://rescript-lang.org/docs/manual/latest/installation` need to be updated about M1 installation fail scenarios and solutions such as installing `npm@6.14`. If not, many users even not try to rescript at all.