### PR TITLE
Fix small typo

### DIFF
--- a/pages/docs/manual/latest/type.mdx
+++ b/pages/docs/manual/latest/type.mdx
@@ -208,7 +208,7 @@ var payloadResults = [
 
 ## Recursive Types
 
-Just like a functions, a type can reference itself within itself using `rec`:
+Just like a function, a type can reference itself within itself using `rec`:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
 


### PR DESCRIPTION
Small typo, should be either "a function" or "functions", not "a functions". Since rest of sentence refers to types as singular "a type", I've kept the same format for the "a function" reference.