### PR TITLE
Fix(footer): Adjusted to always get current year

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "rescript-lang.org",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -1533,7 +1534,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3094,7 +3094,6 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -3972,7 +3971,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -8156,7 +8154,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",

--- a/src/components/Footer.mjs
+++ b/src/components/Footer.mjs
@@ -25,7 +25,7 @@ function Footer(Props) {
                           src: "/static/rescript_logo_black.svg"
                         }), React.createElement("div", {
                           className: "text-16"
-                        }, React.createElement("p", undefined, "© 2021 The ReScript Project"), React.createElement("p", undefined, "Software and assets distribution powered by ", React.createElement(Markdown.A.make, {
+                        }, React.createElement("p", undefined, "© " + String(new Date().getFullYear()) + " The ReScript Project"), React.createElement("p", undefined, "Software and assets distribution powered by ", React.createElement(Markdown.A.make, {
                                   href: "https://www.keycdn.com/",
                                   target: "_blank",
                                   children: "KeyCDN"

--- a/src/components/Footer.res
+++ b/src/components/Footer.res
@@ -10,6 +10,8 @@ module Section = {
   }
 }
 
+let getFullYear = () => Js.String2.make(Js.Date.getFullYear(Js.Date.make()))
+
 @react.component
 let make = () => {
   let linkClass = "hover:underline hover:pointer"
@@ -20,7 +22,7 @@ let make = () => {
       <div>
         <img className="w-40 mb-5" src="/static/rescript_logo_black.svg" />
         <div className="text-16">
-          <p> {React.string(`© 2021 The ReScript Project`)} </p>
+          <p> {React.string(`© ${getFullYear()} The ReScript Project`)} </p>
           <p>
             {React.string("Software and assets distribution powered by ")}
             <Markdown.A href="https://www.keycdn.com/" target="_blank">


### PR DESCRIPTION
I was scrolling thought the lang page and I saw the year was not in the current year.
Added a function that places the current year as copyright.
Don't know hot it works in the US... 
In pages from my country I've added this function to always place the current year in this section of the footer.
Also It could be a small adjust to place year of launch - <now>
If there is anything that needs to be changed I'm here to help :)