### PR TITLE
Changing ReactDOMRe -> ReactDOM

### DIFF
--- a/pages/docs/react/latest/forwarding-refs.mdx
+++ b/pages/docs/react/latest/forwarding-refs.mdx
@@ -97,7 +97,7 @@ module FancyInput = {
         type_="text"
         ?className
         ref=?{Js.Nullable.toOption(ref_)->Belt.Option.map(
-          ReactDOMRe.Ref.domRef,
+          ReactDOM.Ref.domRef,
         )}
       />
       children


### PR DESCRIPTION
Removing the deprecated ReactDOMRe and replacing it with ReactDOM