### PR TITLE
fix: use flex to position items side-by-side

### DIFF
--- a/src/components/Markdown.res
+++ b/src/components/Markdown.res
@@ -468,7 +468,7 @@ module Li = {
       }
     }
 
-    <li className="md-li mt-3 leading-4 ml-2"> elements </li>
+    <li className="flex md-li mt-3 leading-4 ml-2"> elements </li>
   }
 }
 


### PR DESCRIPTION
Fixes a small position issue in Markdown rendering for list items:

## Before
![Screenshot 2022-06-15 at 11 35 59](https://user-images.githubusercontent.com/3763599/173796367-b9a5be46-fe74-4e8d-a6ae-622e3d97624e.png)

## After
![Screenshot 2022-06-15 at 11 36 22](https://user-images.githubusercontent.com/3763599/173796381-7c18fb13-728b-4c5e-9228-fd4cc3dea053.png)
