### PR TITLE
[Fix] Correct typo "re" to "res" in GenType

### DIFF
--- a/pages/docs/gentype/latest/supported-types.mdx
+++ b/pages/docs/gentype/latest/supported-types.mdx
@@ -146,7 +146,7 @@ It's possible to import an existing TS/Flow type as an opaque type in ReScript. 
 ```
 
 defines a type which maps to `weekday` in `SomeFlowTypes.js`.
-See for example [Types.re](https://github.com/reason-association/genType/tree/master/examples/flow-react-example/src/Types.re) and [SomeFlowTypes.js](https://github.com/reason-association/genType/tree/master/examples/flow-react-example/src/SomeFlowTypes.js).
+See for example [Types.res](https://github.com/reason-association/genType/tree/master/examples/flow-react-example/src/Types.res) and [SomeFlowTypes.js](https://github.com/reason-association/genType/tree/master/examples/flow-react-example/src/SomeFlowTypes.js).
 
 ## Recursive Types
 


### PR DESCRIPTION
Hi, this is a small typo fix that corrects a broken link (from `.re` to `.res`).