### PR TITLE
Inform about module filenames

### DIFF
--- a/pages/docs/manual/latest/module.mdx
+++ b/pages/docs/manual/latest/module.mdx
@@ -13,8 +13,10 @@ bindings, nested modules, etc.
 
 ### Creation
 
-To create a module, use the `module` keyword. The module name must start with a
-**capital letter**. Whatever you could place in a `.res` file, you may place
+To create a module, use the `module` keyword. 
+* The module name must start with a **capital letter**. 
+* The module must be placed in a `res` file matching the module name like `ModuleName.res`
+* Whatever you could place in a `.res` file, you may place
 inside a module definition's `{}` block.
 
 <CodeTab labels={["ReScript", "JS Output"]}>


### PR DESCRIPTION
I found by trial and error that modules .res files must match the module names, should be specified in docs, otherwise, ignore this.