### PR TITLE
fix 533

### DIFF
--- a/src/components/Markdown.res
+++ b/src/components/Markdown.res
@@ -468,7 +468,7 @@ module Li = {
       }
     }
 
-    <li className="md-li flex mt-3 leading-4 ml-2"> elements </li>
+    <li className="md-li mt-3 leading-4 ml-2"> elements </li>
   }
 }
 

--- a/styles/_markdown.css
+++ b/styles/_markdown.css
@@ -19,7 +19,7 @@
 
 .md-ol > .md-li::before {
   content: counter(li) ".";
-  @apply font-semibold;
+  @apply absolute font-semibold;
 }
 
 .md-ul > .md-li::before{
@@ -37,7 +37,7 @@
 }
 
 .md-li > p {
-  @apply text-gray-80 ml-4;
+  @apply text-gray-80 ml-5;
 }
 
 .md-li > ul > li p {


### PR DESCRIPTION
- `li` childrens elements are aligned on right: https://rescript-lang.org/docs/manual/latest/installation#integrate-into-an-existing-js-project and https://rescript-lang.org/docs/manual/latest/introduction#difference-vs-typescript
- Revert #533 and fix position