### PR TITLE
Add Neovim Tree-sitter support

### DIFF
--- a/pages/docs/manual/latest/editor-plugins.mdx
+++ b/pages/docs/manual/latest/editor-plugins.mdx
@@ -14,6 +14,7 @@ canonical: "/docs/manual/latest/editor-plugins"
 
 We don't officially support these; use them at your own risk!
 
+- [Neovim Tree-sitter](https://github.com/nkrkv/nvim-treesitter-rescript)
 - [Atom](https://atom.io/packages/ide-rescript)
 - [IDEA](https://github.com/reasonml-editor/reasonml-idea-plugin)
 - [Emacs](https://github.com/reasonml-editor/reason-mode) (only legacy `v8.0.0` Reason/OCaml syntax support)


### PR DESCRIPTION
Shameless plug.

A few people have told me that it’s a miracle they found this plug-in (not because it is extraordinary, but because it’s hard to find). It supplements the official `vim-rescript` to provide more rich syntax highlight, semantic objects, etc.