### PR TITLE
Update primitive-types.mdx

### DIFF
--- a/pages/docs/manual/latest/primitive-types.mdx
+++ b/pages/docs/manual/latest/primitive-types.mdx
@@ -156,7 +156,7 @@ ReScript's `true/false` compiles into a JavaScript `true/false`.
 
 32-bits, truncated when necessary. We provide the usual operations on them: `+`, `-`, `*`, `/`, etc. See [Js.Int](api/js/int) for helper functions.
 
-**Careful when you bind to JavaScript numbers**! Long ones might be truncated. Bind JS number (especially Dates) as **float** instead.
+**Be careful when you bind to JavaScript numbers!** Since ReScript integers have a much smaller range than JavaScript numbers, data might get lost when dealing with large numbers. In those cases it’s much safer to bind the numbers as **float**. Be extra mindful of this when binding to JavaScript Dates and their epoch time.
 
 To improve readability, you may place underscores in the middle of numeric literals such as `1_000_000`. Note that underscores can be placed anywhere within a number, not just every three digits.
 


### PR DESCRIPTION
The description of Integers was not as clear on why you should be careful when binding to numbers as it could be. Tried to describe a bit more why you should be careful.

https://github.com/rescript-association/rescript-lang.org/issues/556