### PR TITLE
Update Js.String[2].match_ return type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ node_modules/
 .next/
 index_data/*.json
 
+# Generated via test examples script
+_tempFile.cmi
+_tempFile.cmj
+_tempFile.cmt
+
 # these docs are checked in, but we consider them frozen.
 pages/docs/manual/v8.0.0/
 pages/docs/manual/v9.0.0/

--- a/compilers/package-lock.json
+++ b/compilers/package-lock.json
@@ -9,9 +9,23 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "rescript-1000": "npm:rescript@10.0.0",
         "rescript-820": "npm:bs-platform@8.2.0",
         "rescript-902": "npm:bs-platform@9.0.2",
         "rescript-912": "npm:rescript@9.1.2"
+      }
+    },
+    "node_modules/rescript-1000": {
+      "name": "rescript",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.0.0.tgz",
+      "integrity": "sha512-LhNg/4+0j8NvoFeslgAeYLlzUwkq6kR6l6v8BnZ61VDTxopK2l96uT1lq5lv1aMxzMDynvE2qnX0zalre+6XxA==",
+      "hasInstallScript": true,
+      "bin": {
+        "bsc": "bsc",
+        "bsrefmt": "bsrefmt",
+        "bstracing": "lib/bstracing",
+        "rescript": "rescript"
       }
     },
     "node_modules/rescript-820": {
@@ -41,6 +55,11 @@
     }
   },
   "dependencies": {
+    "rescript-1000": {
+      "version": "npm:rescript@10.0.0",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.0.0.tgz",
+      "integrity": "sha512-LhNg/4+0j8NvoFeslgAeYLlzUwkq6kR6l6v8BnZ61VDTxopK2l96uT1lq5lv1aMxzMDynvE2qnX0zalre+6XxA=="
+    },
     "rescript-820": {
       "version": "npm:bs-platform@8.2.0",
       "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-8.2.0.tgz",

--- a/compilers/package.json
+++ b/compilers/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "rescript-820": "npm:bs-platform@8.2.0",
     "rescript-902": "npm:bs-platform@9.0.2",
-    "rescript-912": "npm:rescript@9.1.2"
+    "rescript-912": "npm:rescript@9.1.2",
+    "rescript-1000": "npm:rescript@10.0.0"
   }
 }

--- a/pages/docs/manual/latest/api/belt/range.mdx
+++ b/pages/docs/manual/latest/api/belt/range.mdx
@@ -27,7 +27,7 @@ equivalent to `Belt.Array.(forEach(range(start, finish), action))`
 ```res example
 Belt.Range.forEach(0, 4, (i) => Js.log(i))
 
-/**
+/*
  * prints:
  *   0
  *   1

--- a/pages/docs/manual/latest/api/js/string-2.mdx
+++ b/pages/docs/manual/latest/api/js/string-2.mdx
@@ -321,6 +321,7 @@ let match_: (t, Js_re.t) => option<array<option<t>>>
 `match(regexp, str)` matches a `string` against the given `regexp`. If there is no match, it returns `None`. For regular expressions without the g modifier, if there is a match, the return value is `Some(array)` where the array contains:
 - The entire matched string
 - Any capture groups if the regexp had parentheses
+
 For regular expressions with the g modifier, a matched expression returns `Some(array)` with all the matched substrings and no capture groups. Javscript String.prototype.match can return `undefined`  for optional capture groups that are not found, thus the element of the returned array is typed `option<t>`. See [`String.match`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) on MDN.
 
 ```res example

--- a/pages/docs/manual/latest/api/js/string-2.mdx
+++ b/pages/docs/manual/latest/api/js/string-2.mdx
@@ -318,20 +318,19 @@ Js.String2.localeCompare("CAT", "cat") > 0.0
 let match_: (t, Js_re.t) => option<array<option<t>>>
 ```
 
-`match(regexp, str)` matches a `string` against the given `regexp`. If there is no match, it returns `None`. For regular expressions without the g modifier, if there is a match, the return value is `Some(array)` where the array contains:
+`match(str, regexp)` matches a `string` against the given `regexp`. If there is no match, it returns `None`. For regular expressions without the g modifier, if there is a match, the return value is `Some(array)` where the array contains:
 - The entire matched string
 - Any capture groups if the regexp had parentheses
 
 For regular expressions with the g modifier, a matched expression returns `Some(array)` with all the matched substrings and no capture groups. Javscript String.prototype.match can return `undefined`  for optional capture groups that are not found, thus the element of the returned array is typed `option<t>`. See [`String.match`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) on MDN.
 
 ```res example
-Js.String.match_(%re("/b[aeiou]t/"), "The better bats") == Some([Some("bet")])
-Js.String.match_(%re("/b[aeiou]t/g"), "The better bats") == Some([Some("bet"), Some("bat")])
-Js.String.match_(%re("/(\d+)-(\d+)-(\d+)/"), "Today is 2018-04-05.") ==
+Js.String2.match_("The better bats", %re("/b[aeiou]t/")) == Some([Some("bet")])
+Js.String2.match_("The better bats", %re("/b[aeiou]t/g")) == Some([Some("bet"), Some("bat")])
+Js.String2.match_("Today is 2018-04-05.", %re("/(\d+)-(\d+)-(\d+)/")) ==
   Some([Some("2018-04-05"), Some("2018"), Some("04"), Some("05")])
-Js.String.match_(%re("/b[aeiou]g/"), "The large container.") == None
+Js.String2.match_("The large container.", %re("/b[aeiou]g/")) == None
 ```
-
 
 ## normalize
 

--- a/pages/docs/manual/latest/api/js/string-2.mdx
+++ b/pages/docs/manual/latest/api/js/string-2.mdx
@@ -315,21 +315,22 @@ Js.String2.localeCompare("CAT", "cat") > 0.0
 ## match
 
 ```res sig
-let match_: (t, Js_re.t) => option<array<t>>
+let match_: (t, Js_re.t) => option<array<option<t>>>
 ```
 
-`match(str, regexp)` matches a `string` against the given `regexp`. If there is no match, it returns `None`. For regular expressions without the g modifier, if there is a match, the return value is `Some(array)` where the array contains:
+`match(regexp, str)` matches a `string` against the given `regexp`. If there is no match, it returns `None`. For regular expressions without the g modifier, if there is a match, the return value is `Some(array)` where the array contains:
 - The entire matched string
 - Any capture groups if the regexp had parentheses
-For regular expressions with the g modifier, a matched expression returns `Some(array)` with all the matched substrings and no capture groups. See [`String.match`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) on MDN.
+For regular expressions with the g modifier, a matched expression returns `Some(array)` with all the matched substrings and no capture groups. Javscript String.prototype.match can return `undefined`  for optional capture groups that are not found, thus the element of the returned array is typed `option<t>`. See [`String.match`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) on MDN.
 
 ```res example
-Js.String2.match_("The better bats", %re("/b[aeiou]t/")) == Some(["bet"])
-Js.String2.match_("The better bats", %re("/b[aeiou]t/g")) == Some(["bet", "bat"])
-Js.String2.match_("Today is 2018-04-05.", %re("/(\d+)-(\d+)-(\d+)/")) ==
-  Some(["2018-04-05", "2018", "04", "05"])
-Js.String2.match_("The large container.", %re("/b[aeiou]g/")) == None
+Js.String.match_(%re("/b[aeiou]t/"), "The better bats") == Some([Some("bet")])
+Js.String.match_(%re("/b[aeiou]t/g"), "The better bats") == Some([Some("bet"), Some("bat")])
+Js.String.match_(%re("/(\d+)-(\d+)-(\d+)/"), "Today is 2018-04-05.") ==
+  Some([Some("2018-04-05"), Some("2018"), Some("04"), Some("05")])
+Js.String.match_(%re("/b[aeiou]g/"), "The large container.") == None
 ```
+
 
 ## normalize
 

--- a/pages/docs/manual/latest/api/js/string.mdx
+++ b/pages/docs/manual/latest/api/js/string.mdx
@@ -315,19 +315,19 @@ Js.String.localeCompare("cat", "CAT") > 0.0
 ## match
 
 ```res sig
-let match_: (Js_re.t, t) => option<array<t>>
+let match_: (Js_re.t, t) => option<array<option<t>>>
 ```
 
 `match(regexp, str)` matches a `string` against the given `regexp`. If there is no match, it returns `None`. For regular expressions without the g modifier, if there is a match, the return value is `Some(array)` where the array contains:
 - The entire matched string
 - Any capture groups if the regexp had parentheses
-For regular expressions with the g modifier, a matched expression returns `Some(array)` with all the matched substrings and no capture groups. See [`String.match`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) on MDN.
+For regular expressions with the g modifier, a matched expression returns `Some(array)` with all the matched substrings and no capture groups. Javscript String.prototype.match can return `undefined`  for optional capture groups that are not found, thus the element of the returned array is typed `option<t>`. See [`String.match`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) on MDN.
 
 ```res example
-Js.String.match_(%re("/b[aeiou]t/"), "The better bats") == Some(["bet"])
-Js.String.match_(%re("/b[aeiou]t/g"), "The better bats") == Some(["bet", "bat"])
+Js.String.match_(%re("/b[aeiou]t/"), "The better bats") == Some([Some("bet")])
+Js.String.match_(%re("/b[aeiou]t/g"), "The better bats") == Some([Some("bet"), Some("bat")])
 Js.String.match_(%re("/(\d+)-(\d+)-(\d+)/"), "Today is 2018-04-05.") ==
-  Some(["2018-04-05", "2018", "04", "05"])
+  Some([Some("2018-04-05"), Some("2018"), Some("04"), Some("05")])
 Js.String.match_(%re("/b[aeiou]g/"), "The large container.") == None
 ```
 

--- a/pages/docs/manual/latest/api/js/string.mdx
+++ b/pages/docs/manual/latest/api/js/string.mdx
@@ -321,6 +321,7 @@ let match_: (Js_re.t, t) => option<array<option<t>>>
 `match(regexp, str)` matches a `string` against the given `regexp`. If there is no match, it returns `None`. For regular expressions without the g modifier, if there is a match, the return value is `Some(array)` where the array contains:
 - The entire matched string
 - Any capture groups if the regexp had parentheses
+
 For regular expressions with the g modifier, a matched expression returns `Some(array)` with all the matched substrings and no capture groups. Javscript String.prototype.match can return `undefined`  for optional capture groups that are not found, thus the element of the returned array is typed `option<t>`. See [`String.match`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) on MDN.
 
 ```res example

--- a/scripts/test-examples.mjs
+++ b/scripts/test-examples.mjs
@@ -13,7 +13,7 @@ let tempFileNameRegex = /_tempFile\.res/g
 //       see the package.json on how to define another rescript version
 let compilersDir = path.join(__dirname, "..", "compilers")
 
-let bsc = path.join(compilersDir, 'node_modules', 'rescript-912', process.platform, 'bsc.exe')
+let bsc = path.join(compilersDir, 'node_modules', 'rescript-1000', process.platform, 'bsc.exe')
 
 const prepareCompilers = () => {
   if (fs.existsSync(bsc)) {
@@ -82,7 +82,7 @@ glob.sync(__dirname + '/../pages/docs/manual/latest/**/*.mdx').forEach((file) =>
     try {
       // -109 for suppressing `Toplevel expression is expected to have unit type.`
       // Most doc snippets do e.g. `Belt.Array.length(["test"])`, which triggers this
-      child_process.execFileSync(bsc, ['-i', tempFileName, '-w', '-109'], {stdio: 'pipe'})
+      child_process.execFileSync(bsc, [tempFileName, '-w', '-109'], {stdio: 'pipe'})
     } catch (e) {
       process.stdout.write(postprocessOutput(file, e))
       success = false


### PR DESCRIPTION
Also update test example script to test against rescript 10.0.0.
Otherwise, `npm test` will not pass since updated code samples require rescript 10.0.0.

close #551