### PR TITLE
Adjust version for 10.0 docs

### DIFF
--- a/src/common/Constants.mjs
+++ b/src/common/Constants.mjs
@@ -4,7 +4,7 @@
 var allManualVersions = [
   [
     "latest",
-    "v9.1"
+    "v9.1 - v10.0"
   ],
   [
     "v9.0.0",

--- a/src/common/Constants.res
+++ b/src/common/Constants.res
@@ -1,5 +1,5 @@
 // This is used for the version dropdown in the manual layouts
-let allManualVersions = [("latest", "v9.1"), ("v9.0.0", "v8.2 - v9.0"), ("v8.0.0", "v6.0 - v8.2")]
+let allManualVersions = [("latest", "v9.1 - v10.0"), ("v9.0.0", "v8.2 - v9.0"), ("v8.0.0", "v6.0 - v8.2")]
 
 // Used for the DocsOverview and collapsible navigation
 let languageManual = version => {


### PR DESCRIPTION
Will use "latest" just as `9.1`.
New features/changes can be added by mentioning they're new in 10.0.