### PR TITLE
Add a simple Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+SHELL = /bin/bash
+
+node_modules/.bin/rescript:
+	npm install
+	npm run update-index
+
+build: node_modules/.bin/rescript	
+	node_modules/.bin/rescript
+	npm run update-index
+
+dev: build
+	npm run dev
+
+test: build
+	npm run test
+
+clean:
+	rm -r node_modules lib
+
+.DEFAULT_GOAL := build
+
+.PHONY: clean test


### PR DESCRIPTION
Doing `make dev` should perform all the required steps starting from a fresh checkout. Just follows the process described in the README.

Uses the simpler `make build` for just building and updating the index.