### PR TITLE
Remove --save-dev flag from installation instruction

### DIFF
--- a/_blogposts/2021-02-09-release-9-0.mdx
+++ b/_blogposts/2021-02-09-release-9-0.mdx
@@ -17,7 +17,7 @@ ReScript is a robustly typed language that compiles to efficient and human-reada
 Use `npm` to install the newest [9.0.1 release](https://www.npmjs.com/package/bs-platform/v/9.0.1) with the following command:
 
 ```
-npm install bs-platform@9.0.1 --save-dev
+npm install bs-platform@9.0.1
 ```
 
 You can also try our new release in the [Online Playground](/try).

--- a/pages/docs/gentype/latest/getting-started.mdx
+++ b/pages/docs/gentype/latest/getting-started.mdx
@@ -14,7 +14,7 @@ canonical: "/docs/gentype/latest/getting-started"
 Install the binaries via `npm` (or `yarn`):
 
 ```
-npm install --save-dev gentype
+npm install gentype --save-dev
 
 # Verify installed gentype binary
 npx gentype --help

--- a/pages/docs/manual/latest/build-external-stdlib.mdx
+++ b/pages/docs/manual/latest/build-external-stdlib.mdx
@@ -25,7 +25,7 @@ Say you want to publish a JS-only ReScript 9.0 library. Install the packages lik
 
 ```sh
 npm install bs-platform@9.0.0 --save-dev
-npm install @rescript/std@9.0.0 --save
+npm install @rescript/std@9.0.0
 ```
 
 Then add this to `bsconfig.json`:

--- a/pages/docs/manual/latest/converting-from-js.mdx
+++ b/pages/docs/manual/latest/converting-from-js.mdx
@@ -13,7 +13,7 @@ ReScript offers a unique project conversion methodology which:
 
 ## Step 1: Install ReScript
 
-Run `npm install rescript --save-dev` on your project, then imitate our [New Project](installation#new-project) workflow by adding a `bsconfig.json` at the root. Then start `npx rescript build -w`.
+Run `npm install rescript` on your project, then imitate our [New Project](installation#new-project) workflow by adding a `bsconfig.json` at the root. Then start `npx rescript build -w`.
 
 ## Step 2: Copy Paste the Entire JS File
 

--- a/pages/docs/manual/latest/installation.mdx
+++ b/pages/docs/manual/latest/installation.mdx
@@ -29,9 +29,9 @@ During development, instead of running `npm run build` each time to compile, use
 
 If you already have a JavaScript project into which you'd like to add ReScript:
 
-- Install ReScript locally as a [devDependency](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file):
+- Install ReScript locally:
   ```sh
-  npm install rescript --save-dev
+  npm install rescript
   ```
 - Create a ReScript build configuration at the root:
   ```json

--- a/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
+++ b/pages/docs/manual/latest/migrate-from-bucklescript-reason.mdx
@@ -16,7 +16,7 @@ ReScript is a rebranding and cleanup of BuckleScript (since `v8.2.0`) & Reason (
 There are lots of exciting improvements in the new syntax (features, speed, error messages, etc.). The upgrade is trivial, backward-compatible and can be done on a per-file basis:
 
 ```
-npm install rescript@9 --save-dev
+npm install rescript@9
 
 # Also works with .rei / .ml / .mli / etc
 npx rescript convert src/MyFile.re

--- a/pages/docs/manual/latest/promise.mdx
+++ b/pages/docs/manual/latest/promise.mdx
@@ -15,7 +15,7 @@ There is currently no support for `async` and `await` keywords in ReScript; thou
 Our up to date Promise bindings are currently not part of the the standard library. For now, please install them separately:
 
 ```sh
-npm install @ryyppy/rescript-promise --save
+npm install @ryyppy/rescript-promise
 ```
 
 In your `bsconfig.json`:

--- a/pages/docs/react/latest/installation.mdx
+++ b/pages/docs/react/latest/installation.mdx
@@ -14,7 +14,7 @@ canonical: "/docs/react/latest/installation"
 Add following dependency to your ReScript project (in case you don't have any project yet, check out the [installation instructions](/docs/manual/latest/installation) in the manual):
 
 ```
-npm install @rescript/react --save
+npm install @rescript/react
 ```
 
 Then add the following setting to your existing `bsconfig.json`:

--- a/src/layouts/LandingPageLayout.mjs
+++ b/src/layouts/LandingPageLayout.mjs
@@ -199,7 +199,7 @@ function LandingPageLayout$QuickInstall$Instructions(Props) {
                   className: "captions x text-gray-40 mb-2 mt-1"
                 }, "You can quickly add ReScript to your existing JavaScript codebase via npm / yarn:"), React.createElement("div", {
                   className: "w-full space-y-2"
-                }, copyBox("npm install rescript --save-dev"), copyBox("npx rescript init .")));
+                }, copyBox("npm install rescript"), copyBox("npx rescript init .")));
 }
 
 function LandingPageLayout$QuickInstall(Props) {

--- a/src/layouts/LandingPageLayout.res
+++ b/src/layouts/LandingPageLayout.res
@@ -244,7 +244,7 @@ module QuickInstall = {
           )}
         </div>
         <div className="w-full space-y-2">
-          {copyBox("npm install rescript --save-dev")} {copyBox("npx rescript init .")}
+          {copyBox("npm install rescript")} {copyBox("npx rescript init .")}
         </div>
       </div>
     }


### PR DESCRIPTION
ReScript shouldn't be installed as a `devDependency` because it contains runtime stdlib. It'll cause a failing build when installing dependencies with `npm ci --omit=dev`.
Also, another benefit is the installation script looks much cleaner for newcomers without `--save-dev`.

I've removed all occurrences of `--save-dev` besides:
- [build-external-stdlib.mdx](https://github.com/DZakh-forks/rescript-lang.org/blob/6078f3956461b2a83de24dd67a606f1db93b319a/pages/docs/manual/latest/build-external-stdlib.mdx?plain=1#L22-L29) - because it looks like it makes sense to have `--save-dev` when we have `@rescript/std`.
- [Gentype's getting-started.mdx](https://github.com/DZakh-forks/rescript-lang.org/blob/6078f3956461b2a83de24dd67a606f1db93b319a/pages/docs/gentype/latest/getting-started.mdx?plain=1#L17) - I haven't used Gentype for a while, so I don't remember whether it should have `--save-dev` or not. Just moved the flag after the package name to look more natural.
- [Old upgrade-to-v7.mdx](https://github.com/DZakh-forks/rescript-lang.org/blob/master/pages/docs/reason-compiler/latest/upgrade-to-v7.mdx) - I haven't found it on the website, looks like not used at all. Decided not to touch 😅
