### PR TITLE
Use the res prefix for convenience npm scripts

### DIFF
--- a/pages/docs/manual/latest/installation.mdx
+++ b/pages/docs/manual/latest/installation.mdx
@@ -31,7 +31,7 @@ If you already have a JavaScript project into which you'd like to add ReScript:
 
 - Install ReScript locally as a [devDependency](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file):
   ```sh
-  npm install rescript --save-dev 
+  npm install rescript --save-dev
   ```
 - Create a ReScript build configuration at the root:
   ```json
@@ -57,14 +57,15 @@ If you already have a JavaScript project into which you'd like to add ReScript:
 - Add convenience `npm` scripts to `package.json`:
   ```json
   "scripts": {
-    "re:build": "rescript",
-    "re:start": "rescript build -w"
+    "res:build": "rescript",
+    "res:start": "rescript build -w"
   }
   ```
 
 Since ReScript compiles to clean readable JS files, the rest of your existing toolchain (e.g. Babel and Webpack) should just work!
 
 Helpful guides:
+
 - [Converting from JS](converting-from-js).
 - [Shared Data Types](shared-data-types).
 - [Import from/Export to JS](import-from-export-to-js).


### PR DESCRIPTION
> There are some unrelated autoformatting changes. I thought they won't harm, so decided to keep them.