### PR TITLE
Update installation guilde: Rename convenience npm script from res:start to res:dev

### DIFF
--- a/pages/docs/manual/latest/installation.mdx
+++ b/pages/docs/manual/latest/installation.mdx
@@ -58,7 +58,7 @@ If you already have a JavaScript project into which you'd like to add ReScript:
   ```json
   "scripts": {
     "res:build": "rescript",
-    "res:start": "rescript build -w"
+    "res:dev": "rescript build -w"
   }
   ```
 


### PR DESCRIPTION
The logic behind the PR is that recently the `start` script often started being used in the context of running a built application. While scripts for development are usually called `dev` or `watch`.

- https://docs.npmjs.com/cli/v8/using-npm/scripts#npm-start