### PR TITLE
Fix typo Specalized -> Specialized

### DIFF
--- a/pages/docs/manual/latest/api/belt/hash-map-int.mdx
+++ b/pages/docs/manual/latest/api/belt/hash-map-int.mdx
@@ -2,7 +2,7 @@
 
 <Intro>
 
-Specalized when key type is `int`, more efficient than the generic type
+Specialized when key type is `int`, more efficient than the generic type
 
 </Intro>
 

--- a/pages/docs/manual/latest/api/belt/hash-map-string.mdx
+++ b/pages/docs/manual/latest/api/belt/hash-map-string.mdx
@@ -2,7 +2,7 @@
 
 <Intro>
 
-Specalized when key type is `string`, more efficient than the generic type
+Specialized when key type is `string`, more efficient than the generic type
 
 </Intro>
 

--- a/pages/docs/manual/latest/api/belt/map-int.mdx
+++ b/pages/docs/manual/latest/api/belt/map-int.mdx
@@ -2,7 +2,7 @@
 
 <Intro>
 
-Specalized when key type is `int`, more efficient than the generic type, its compare behavior is fixed using the built-in comparison
+Specialized when key type is `int`, more efficient than the generic type, its compare behavior is fixed using the built-in comparison
 
 </Intro>
 

--- a/pages/docs/manual/latest/api/belt/map-string.mdx
+++ b/pages/docs/manual/latest/api/belt/map-string.mdx
@@ -2,7 +2,7 @@
 
 <Intro>
 
-Specalized when key type is `string`, more efficient than the generic type, its compare behavior is fixed using the built-in comparison
+Specialized when key type is `string`, more efficient than the generic type, its compare behavior is fixed using the built-in comparison
 
 </Intro>
 

--- a/pages/docs/manual/latest/api/belt/set-int.mdx
+++ b/pages/docs/manual/latest/api/belt/set-int.mdx
@@ -2,7 +2,7 @@
 
 <Intro>
 
-Specalized when value type is `int`, more efficient than the generic type, its compare behavior is fixed using the built-in comparison.
+Specialized when value type is `int`, more efficient than the generic type, its compare behavior is fixed using the built-in comparison.
 
 </Intro>
 

--- a/pages/docs/manual/latest/api/belt/set-string.mdx
+++ b/pages/docs/manual/latest/api/belt/set-string.mdx
@@ -2,7 +2,7 @@
 
 <Intro>
 
-Specalized when value type is `string`, more efficient than the generic type, its compare behavior is fixed using the built-in comparison.
+Specialized when value type is `string`, more efficient than the generic type, its compare behavior is fixed using the built-in comparison.
 
 </Intro>
 

--- a/pages/docs/manual/latest/api/belt/sort-array.mdx
+++ b/pages/docs/manual/latest/api/belt/sort-array.mdx
@@ -6,7 +6,7 @@
 module Int = Belt.SortArray.Int
 ```
 
-Specalized when key type is `int`, more efficient than the generic type
+Specialized when key type is `int`, more efficient than the generic type
 
 ## SortArrayString
 
@@ -14,7 +14,7 @@ Specalized when key type is `int`, more efficient than the generic type
 module String = Belt.SortArray.String
 ```
 
-Specalized when key type is `string`, more efficient than the generic type
+Specialized when key type is `string`, more efficient than the generic type
 
 ## strictlySortedLengthU
 


### PR DESCRIPTION
Just a small typo that seems to have made its way into a few files.