### PR TITLE
Fix missing underscore

### DIFF
--- a/scripts/extract-indices.mjs
+++ b/scripts/extract-indices.mjs
@@ -22,13 +22,13 @@ const headers = options => (tree, file) => {
   tree.children.forEach(child => {
     if (child.type === "heading" && child.depth === 1) {
       if (child.children.length > 0) {
-        mainHeader = child.children[0].value;
+        mainHeader = child.children.map(element => element.value).join("");
       }
     }
     if (child.type === "heading" && child.depth === 2) {
       if (child.children.length > 0) {
         const id = child.data.id || "";
-        const name = child.children[0].value;
+        const name = child.children.map(element => element.value).join("");
         headers.push({ name, href: id });
       }
     }


### PR DESCRIPTION
The current behavior is: underscore is included in the heading, but missing in the sidebar.
For example:
![image](https://user-images.githubusercontent.com/112108686/196079506-8cc3a3d4-3bbb-4e32-b56b-0af2865ac79a.png)
the tail `_` of `test_` is missing in the sidebar.

It seems was originally raised from here:
https://github.com/rescript-association/rescript-lang.org/blob/b0da61146a0718337957e79569b5386220d55f93/scripts/extract-indices.mjs#L31
We only fetch the value of the first child of a [mdast](https://github.com/syntax-tree/mdast) node as the name attribute.
But when a heading contains escape characters like `\_`, children will be a list.  Like
```js
[
  {
    type: 'text',
    value: 'test',
    position: Position { start: [Object], end: [Object], indent: [] }
  },
  {
    type: 'text',
    value: '_',
    position: Position { start: [Object], end: [Object], indent: [] }
  }
]
```
This PR seems to give a fix.