### PR TITLE
fix: An building error on windows platform which caused by esmodule _…

### DIFF
--- a/scripts/extract-indices.mjs
+++ b/scripts/extract-indices.mjs
@@ -14,7 +14,8 @@ import path from "path";
 import fs from "fs";
 import { URL } from 'url';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const pathname = new URL('.', import.meta.url).pathname;
+const __dirname = process.platform !== 'win32' ? pathname : pathname.substring(1)
 
 const headers = options => (tree, file) => {
   const headers = [];

--- a/scripts/extract-syntax.mjs
+++ b/scripts/extract-syntax.mjs
@@ -4,7 +4,8 @@ import path from "path";
 import fs from "fs";
 import { URL } from 'url';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const pathname = new URL('.', import.meta.url).pathname;
+const __dirname = process.platform !== 'win32' ? pathname : pathname.substring(1)
 
 const processFile = filepath => {
   const raw = fs.readFileSync(filepath, "utf8");

--- a/scripts/extract-tocs.mjs
+++ b/scripts/extract-tocs.mjs
@@ -12,7 +12,8 @@ import path from "path";
 import fs from "fs";
 import { URL } from 'url';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const pathname = new URL('.', import.meta.url).pathname;
+const __dirname = process.platform !== 'win32' ? pathname : pathname.substring(1)
 
 // orderArr: ["introduction", "overview",,...]
 const orderFiles = (filepaths, orderArr) => {

--- a/scripts/test-examples.mjs
+++ b/scripts/test-examples.mjs
@@ -4,7 +4,8 @@ import child_process from "child_process";
 import path from "path";
 import { URL } from 'url';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const pathname = new URL('.', import.meta.url).pathname;
+const __dirname = process.platform !== 'win32' ? pathname : pathname.substring(1)
 
 let tempFileName = path.join(__dirname, '..', '_tempFile.res')
 let tempFileNameRegex = /_tempFile\.res/g

--- a/scripts/test-hrefs.mjs
+++ b/scripts/test-hrefs.mjs
@@ -16,7 +16,8 @@ import urlModule from "url";
 import { URL } from 'url';
 import {getAllPosts, blogPathToSlug} from '../src/common/BlogApi.mjs'
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const pathname = new URL('.', import.meta.url).pathname;
+const __dirname = process.platform !== 'win32' ? pathname : pathname.substring(1)
 
 const mapBlogFilePath = path => {
   const match = path.match(/\.\/_blogposts\/(.*\.mdx)/);


### PR DESCRIPTION
When I join the work about traslating rescript-lang site to chinese [here](https://github.com/butterunderflow/rescript-lang.org-chinese-translation), I have found an error of building the site project. so I added some code to support unix-like and win32 system at the same time.