### PR TITLE
fix: syntax lookup module keyword

### DIFF
--- a/misc_docs/syntax/specialvalues_module.mdx
+++ b/misc_docs/syntax/specialvalues_module.mdx
@@ -1,5 +1,5 @@
 ---
-id: "module"
+id: "__module__"
 keywords: ["module"]
 name: "__MODULE__"
 summary: "This is the `__MODULE__` special value."


### PR DESCRIPTION
The language constructor `module` show content of `__MODULE__` special value.