### PR TITLE
Fix simple calculation mistake in Belt.Array.map code example

### DIFF
--- a/pages/docs/manual/latest/api/belt/array.mdx
+++ b/pages/docs/manual/latest/api/belt/array.mdx
@@ -503,7 +503,7 @@ let map: (array<'a>, 'a => 'b) => array<'b>
 Returns a new array by calling `f` for each element of `xs` from the beginning to end.
 
 ```res example
-Belt.Array.map([1, 2], (x) => x + 1) == [3, 4]
+Belt.Array.map([1, 2], (x) => x + 2) == [3, 4]
 ```
 
 ## getByU


### PR DESCRIPTION
Hello 😄 
The current code example of `Belt.Array.map` has simple calculation error. 
<img width="1403" alt="Screen Shot 2022-11-14 at 6 32 00 PM" src="https://user-images.githubusercontent.com/17538785/201624968-d11d474d-757f-4704-bd35-3abdaf60676a.png">

So I changed `f` from `(x) => x + 1` to `(x) => x + 2`.
<img width="742" alt="Screen Shot 2022-11-14 at 6 38 23 PM" src="https://user-images.githubusercontent.com/17538785/201626326-006f17da-bdde-428f-a5c2-cf54f2415514.png">
