### PR TITLE
Update highlight.js signature to get rid of deprecated messages

### DIFF
--- a/src/common/HighlightJs.mjs
+++ b/src/common/HighlightJs.mjs
@@ -10,11 +10,14 @@ import * as Core from "highlight.js/lib/core";
 function renderHLJS(highlightedLinesOpt, darkmodeOpt, code, lang, param) {
   var highlightedLines = highlightedLinesOpt !== undefined ? highlightedLinesOpt : [];
   var darkmode = darkmodeOpt !== undefined ? darkmodeOpt : false;
+  var options = {
+    language: lang
+  };
   var match;
   try {
     match = [
       lang,
-      Core.highlight(lang, code).value
+      Core.highlight(code, options).value
     ];
   }
   catch (raw_exn){

--- a/src/common/HighlightJs.res
+++ b/src/common/HighlightJs.res
@@ -1,12 +1,15 @@
+type options = {language: string}
+
 @deriving(abstract)
 type highlightResult = {value: string}
 
 @module("highlight.js/lib/core")
-external highlight: (~lang: string, ~value: string) => highlightResult = "highlight"
+external highlight: (~code: string, ~options: options) => highlightResult = "highlight"
 
 let renderHLJS = (~highlightedLines=[], ~darkmode=false, ~code: string, ~lang: string, ()) => {
   // If the language couldn't be parsed, we will fall back to text
-  let (lang, highlighted) = try (lang, highlight(~lang, ~value=code)->valueGet) catch {
+  let options = {language: lang}
+  let (lang, highlighted) = try (lang, highlight(~code, ~options)->valueGet) catch {
   | Js.Exn.Error(_) => ("text", code)
   }
 


### PR DESCRIPTION
```
Deprecated as of 10.7.0. highlight(lang, code, ...args) has been deprecated.
Deprecated as of 10.7.0. Please use highlight(code, options) instead.
https://github.com/highlightjs/highlight.js/issues/2277
```