### PR TITLE
fix: docs tab not activating on the/docs/react path

### DIFF
--- a/src/components/Navigation.res
+++ b/src/components/Navigation.res
@@ -429,6 +429,7 @@ let make = (~fixed=true, ~overlayState: (bool, (bool => bool) => unit)) => {
         let url = Url.parse(route)
         switch url {
         | {base: ["docs"]}
+        | {base: ["docs", "react"]}
         | {base: ["docs", "gentype"]}
         | {base: ["docs", "manual"]} =>
           switch Belt.Array.get(url.pagepath, 0) {


### PR DESCRIPTION
This pull request includes the following changes:

Fixing the `Docs` tab not activating on /docs/react paths.

Here's a captured image of the currently deployed version, which should be activated(or highlighted) like other sibling menus(like manual or genType pages)

<img width="485" alt="image" src="https://user-images.githubusercontent.com/105708964/206391822-94306387-6f32-4f7b-be56-f5e503bff2ff.png">