### PR TITLE
Fix canonical/add edit button

### DIFF
--- a/pages/docs/react/latest/migrate-from-v3.mdx
+++ b/pages/docs/react/latest/migrate-from-v3.mdx
@@ -1,7 +1,7 @@
 ---
-title:
+title: Migrate from JSX v3
 description: "Migrate from JSX v3"
-canonical: "/docs/react/latest/jsx-v3-v4"
+canonical: "/docs/react/latest/migrate-from-v3"
 ---
 
 # Migrate from JSX v3


### PR DESCRIPTION
I've noticed that an Edit button is missing on [the Migrate from JSX v3's doc page](https://rescript-lang.org/docs/react/latest/migrate-from-v3). Turns out its canonical path is pointing to a different one. 

This PR 
- fixes the canonical url 
- adds an Edit button
- adds the title of the meta info
of the documentation for Migrate from JSX v3.


<br>

| Before | After |
| --------------- | --------------- |
|![edit button before](https://user-images.githubusercontent.com/78751231/208687143-f570465f-c5dd-4079-80e7-26a6737d7e5f.png) | ![edit button after](https://user-images.githubusercontent.com/78751231/208687206-5de1d49b-25f8-4f3e-9a62-fa5b22f24265.png) |