### PR TITLE
Migrate to async/await

### DIFF
--- a/src/Blog.res
+++ b/src/Blog.res
@@ -324,7 +324,7 @@ let default = (props: props): React.element => {
   </>
 }
 
-let getStaticProps: Next.GetStaticProps.t<props, params> = _ctx => {
+let getStaticProps: Next.GetStaticProps.t<props, params> = async _ctx => {
   let (archived, nonArchived) = BlogApi.getAllPosts()->Belt.Array.partition(data => data.archived)
 
   let props = {
@@ -332,5 +332,5 @@ let getStaticProps: Next.GetStaticProps.t<props, params> = _ctx => {
     archived,
   }
 
-  Js.Promise.resolve({"props": props})
+  {"props": props}
 }

--- a/src/BlogArticle.res
+++ b/src/BlogArticle.res
@@ -217,7 +217,7 @@ let default = (props: props) => {
   <MainLayout> content </MainLayout>
 }
 
-let getStaticProps: Next.GetStaticProps.t<props, Params.t> = ctx => {
+let getStaticProps: Next.GetStaticProps.t<props, Params.t> = async ctx => {
   open Next.GetStaticProps
   let {params} = ctx
 
@@ -229,11 +229,11 @@ let getStaticProps: Next.GetStaticProps.t<props, Params.t> = ctx => {
   }
 
   let props = {path: path}
-  let ret = {"props": props}
-  Promise.resolve(ret)
+
+  {"props": props}
 }
 
-let getStaticPaths: Next.GetStaticPaths.t<Params.t> = () => {
+let getStaticPaths: Next.GetStaticPaths.t<Params.t> = async () => {
   open Next.GetStaticPaths
 
   let paths = BlogApi.getAllPosts()->Belt.Array.map(postData => {
@@ -241,6 +241,6 @@ let getStaticPaths: Next.GetStaticPaths.t<Params.t> = () => {
       Params.slug: BlogApi.blogPathToSlug(postData.path),
     },
   })
-  let ret = {paths, fallback: false}
-  Promise.resolve(ret)
+
+  {paths, fallback: false}
 }

--- a/src/bindings/RescriptCompilerApi.res
+++ b/src/bindings/RescriptCompilerApi.res
@@ -58,6 +58,13 @@ module Version = {
     | _ => UnknownVersion(apiVersion)
     }
 
+  let toString = t =>
+    switch t {
+    | V1 => "1.0"
+    | V2 => "2.0"
+    | UnknownVersion(version) => version
+    }
+
   let defaultTargetLang = Lang.Res
 
   let availableLanguages = t =>

--- a/src/bindings/RescriptCompilerApi.resi
+++ b/src/bindings/RescriptCompilerApi.resi
@@ -28,6 +28,8 @@ module Version: {
   // Helps finding the right API version
   let fromString: string => t
 
+  let toString: t => string
+
   let defaultTargetLang: Lang.t
 
   let availableLanguages: t => array<Lang.t>

--- a/src/common/CompilerManagerHook.res
+++ b/src/common/CompilerManagerHook.res
@@ -101,40 +101,28 @@ let migrateLibraries = (~version: string, libraries: array<string>): array<strin
     We coupled the compiler / library loading to prevent ppl to try loading compiler / cmij files
     separately and cause all kinds of race conditions.
  */
-let attachCompilerAndLibraries = (~version: string, ~libraries: array<string>, ()): Promise.t<
-  result<unit, array<string>>,
+let attachCompilerAndLibraries = async (~version: string, ~libraries: array<string>, ()): result<
+  unit,
+  array<string>,
 > => {
   let compilerUrl = CdnMeta.getCompilerUrl(version)
 
   // Useful for debugging our local build
   /* let compilerUrl = "/static/linked-bs-bundle.js"; */
 
-  LoadScript.loadScriptPromise(compilerUrl)
-  ->Promise.thenResolve(r => {
-    switch r {
-    | Error(_) => Error(j`Could not load compiler from url $compilerUrl`)
-    | _ => r
-    }
-  })
-  ->Promise.then(r => {
-    let promises = switch r {
-    | Ok() =>
-      Belt.Array.map(libraries, lib => {
-        let cmijUrl = CdnMeta.getLibraryCmijUrl(version, lib)
-        LoadScript.loadScriptPromise(cmijUrl)->Promise.thenResolve(
-          r =>
-            switch r {
-            | Error(_) => Error(j`Could not load cmij from url $cmijUrl`)
-            | _ => r
-            },
-        )
-      })
-    | Error(msg) => [Promise.resolve(Error(msg))]
-    }
+  switch await LoadScript.loadScriptPromise(compilerUrl) {
+  | Error(_) => Error([`Could not load compiler from url ${compilerUrl}`])
+  | Ok(_) =>
+    let promises = Belt.Array.map(libraries, async lib => {
+      let cmijUrl = CdnMeta.getLibraryCmijUrl(version, lib)
+      switch await LoadScript.loadScriptPromise(cmijUrl) {
+      | Error(_) => Error(`Could not load cmij from url ${cmijUrl}`)
+      | r => r
+      }
+    })
 
-    Promise.all(promises)
-  })
-  ->Promise.thenResolve(all => {
+    let all = await Promise.all(promises)
+
     let errors = Belt.Array.keepMap(all, r => {
       switch r {
       | Error(msg) => Some(msg)
@@ -146,7 +134,7 @@ let attachCompilerAndLibraries = (~version: string, ~libraries: array<string>, (
     | [] => Ok()
     | errs => Error(errs)
     }
-  })
+  }
 }
 
 type error =
@@ -330,19 +318,18 @@ let useCompilerManager = (~initialLang: Lang.t=Res, ~onAction: option<action => 
     })
 
   React.useEffect1(() => {
-    switch state {
-    | Init =>
-      switch CdnMeta.versions {
-      | [] => dispatchError(SetupError(j`No compiler versions found`))
-      | versions =>
-        let latest = versions[0]
+    let updateState = async () => {
+      switch state {
+      | Init =>
+        switch CdnMeta.versions {
+        | [] => dispatchError(SetupError("No compiler versions found"))
+        | versions =>
+          let latest = versions[0]
 
-        // Latest version is already running on @rescript/react
-        let libraries = ["@rescript/react"]
+          // Latest version is already running on @rescript/react
+          let libraries = ["@rescript/react"]
 
-        attachCompilerAndLibraries(~version=latest, ~libraries, ())
-        ->Promise.thenResolve(result =>
-          switch result {
+          switch await attachCompilerAndLibraries(~version=latest, ~libraries, ()) {
           | Ok() =>
             let instance = Compiler.make()
             let apiVersion = apiVersion->Version.fromString
@@ -363,37 +350,30 @@ let useCompilerManager = (~initialLang: Lang.t=Res, ~onAction: option<action => 
               ->Js.Array2.find(l => l === initialLang)
               ->Belt.Option.getWithDefault(Version.defaultTargetLang)
 
-            setState(
-              _ => Ready({
-                selected,
-                targetLang,
-                versions,
-                errors: [],
-                result: FinalResult.Nothing,
-              }),
-            )
+            setState(_ => Ready({
+              selected,
+              targetLang,
+              versions,
+              errors: [],
+              result: FinalResult.Nothing,
+            }))
           | Error(errs) =>
             let msg = Js.Array2.joinWith(errs, "; ")
 
             dispatchError(CompilerLoadingError(msg))
           }
-        )
-        ->ignore
-      }
-    | SwitchingCompiler(ready, version, libraries) =>
-      let migratedLibraries = libraries->migrateLibraries(~version)
+        }
+      | SwitchingCompiler(ready, version, libraries) =>
+        let migratedLibraries = libraries->migrateLibraries(~version)
 
-      attachCompilerAndLibraries(~version, ~libraries=migratedLibraries, ())
-      ->Promise.thenResolve(result =>
-        switch result {
+        switch await attachCompilerAndLibraries(~version, ~libraries=migratedLibraries, ()) {
         | Ok() =>
           // Make sure to remove the previous script from the DOM as well
           LoadScript.removeScript(~src=CdnMeta.getCompilerUrl(ready.selected.id))
 
           // We are removing the previous libraries, therefore we use ready.selected here
-          Belt.Array.forEach(
-            ready.selected.libraries,
-            lib => LoadScript.removeScript(~src=CdnMeta.getLibraryCmijUrl(ready.selected.id, lib)),
+          Belt.Array.forEach(ready.selected.libraries, lib =>
+            LoadScript.removeScript(~src=CdnMeta.getLibraryCmijUrl(ready.selected.id, lib))
           )
 
           let instance = Compiler.make()
@@ -410,48 +390,51 @@ let useCompilerManager = (~initialLang: Lang.t=Res, ~onAction: option<action => 
             instance,
           }
 
-          setState(
-            _ => Ready({
-              selected,
-              targetLang: Version.defaultTargetLang,
-              versions: ready.versions,
-              errors: [],
-              result: FinalResult.Nothing,
-            }),
-          )
+          setState(_ => Ready({
+            selected,
+            targetLang: Version.defaultTargetLang,
+            versions: ready.versions,
+            errors: [],
+            result: FinalResult.Nothing,
+          }))
         | Error(errs) =>
           let msg = Js.Array2.joinWith(errs, "; ")
 
           dispatchError(CompilerLoadingError(msg))
         }
-      )
-      ->ignore
-    | Compiling(ready, (lang, code)) =>
-      let apiVersion = ready.selected.apiVersion
-      let instance = ready.selected.instance
+      | Compiling(ready, (lang, code)) =>
+        let apiVersion = ready.selected.apiVersion
+        let instance = ready.selected.instance
 
-      let compResult = switch apiVersion {
-      | Version.V1 =>
-        switch lang {
-        | Lang.OCaml => instance->Compiler.ocamlCompile(code)
-        | Lang.Reason => instance->Compiler.reasonCompile(code)
-        | Lang.Res => instance->Compiler.resCompile(code)
+        let compResult = switch apiVersion {
+        | Version.V1 =>
+          switch lang {
+          | Lang.OCaml => instance->Compiler.ocamlCompile(code)
+          | Lang.Reason => instance->Compiler.reasonCompile(code)
+          | Lang.Res => instance->Compiler.resCompile(code)
+          }
+        | Version.V2 =>
+          switch lang {
+          | Lang.OCaml => instance->Compiler.ocamlCompile(code)
+          | Lang.Reason =>
+            CompilationResult.UnexpectedError(
+              `Reason not supported with API version "${apiVersion->RescriptCompilerApi.Version.toString}"`,
+            )
+          | Lang.Res => instance->Compiler.resCompile(code)
+          }
+        | UnknownVersion(version) =>
+          CompilationResult.UnexpectedError(
+            `Can't handle result of compiler API version "${version}"`,
+          )
         }
-      | Version.V2 =>
-        switch lang {
-        | Lang.OCaml => instance->Compiler.ocamlCompile(code)
-        | Lang.Reason =>
-          CompilationResult.UnexpectedError(j`Reason not supported with API version "$apiVersion"`)
-        | Lang.Res => instance->Compiler.resCompile(code)
-        }
-      | UnknownVersion(apiVersion) =>
-        CompilationResult.UnexpectedError(j`Can't handle result of compiler API version "$apiVersion"`)
+
+        setState(_ => Ready({...ready, result: FinalResult.Comp(compResult)}))
+      | SetupFailed(_)
+      | Ready(_) => ()
       }
-
-      setState(_ => Ready({...ready, result: FinalResult.Comp(compResult)}))
-    | SetupFailed(_)
-    | Ready(_) => ()
     }
+
+    updateState()->ignore
     None
   }, [state])
 


### PR DESCRIPTION
Migrating most obvious Promise usages to the new `async` / `await` syntax. Also took the opportunity to clean up some obsolete `j` string interpolations.