### PR TITLE
Remove the Atom editor section

### DIFF
--- a/pages/docs/manual/latest/editor-plugins.mdx
+++ b/pages/docs/manual/latest/editor-plugins.mdx
@@ -15,6 +15,5 @@ canonical: "/docs/manual/latest/editor-plugins"
 We don't officially support these; use them at your own risk!
 
 - [Neovim Tree-sitter](https://github.com/nkrkv/nvim-treesitter-rescript)
-- [Atom](https://atom.io/packages/ide-rescript)
 - [IDEA](https://github.com/reasonml-editor/reasonml-idea-plugin)
 - [Emacs](https://github.com/reasonml-editor/reason-mode) (only legacy `v8.0.0` Reason/OCaml syntax support)


### PR DESCRIPTION
Since (unfortunately) the Atom text editor support has discontinued recently, it seems like there'll be no need to suggest Atom as an editor plugin for ReScript anymore.