### PR TITLE
Fix Sublime plugin link

### DIFF
--- a/pages/docs/manual/latest/editor-plugins.mdx
+++ b/pages/docs/manual/latest/editor-plugins.mdx
@@ -7,7 +7,7 @@ canonical: "/docs/manual/latest/editor-plugins"
 # Editor Plugins
 
 - [VSCode](https://marketplace.visualstudio.com/items?itemName=chenglou92.rescript-vscode)
-- [Sublime Text](https://github.com/reasonml-editor/sublime-reason)
+- [Sublime Text](https://github.com/rescript-lang/rescript-sublime)
 - [Vim/Neovim](https://github.com/rescript-lang/vim-rescript)
 
 ## Community Supported


### PR DESCRIPTION
Hi, looks like your docs have an outdated link for the Sublime plugin. [People on the forum get confused about this too.](https://forum.rescript-lang.org/t/supported-editor-plugins/3255) This PR fixes it.