### PR TITLE
prerequisites: update node version to 14

### DIFF
--- a/pages/docs/manual/latest/installation.mdx
+++ b/pages/docs/manual/latest/installation.mdx
@@ -8,7 +8,7 @@ canonical: "/docs/manual/latest/installation"
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) version >= 10
+- [Node.js](https://nodejs.org/) version >= 14
 - [npm](https://docs.npmjs.com/cli/) (which comes with Node.js) or [Yarn](https://yarnpkg.com/)
 
 ## New Project


### PR DESCRIPTION
Since 10.1.0 ReScript requires node v14.

The format command raise an error.

```
./node_modules/.bin/rescript format src/let_binding.res
```

```
Uncaught Exception { Error: Cannot find module 'node:util'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/home/pedro/Desktop/learning-rescript/node_modules/rescript/scripts/rescript_format.js:8:12)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3) code: 'MODULE_NOT_FOUND' }
```

ReScript: 10.1.0
Node: v10.24.1

The format command only works with node v14.

[CHANGELOG](https://github.com/rescript-lang/rescript-compiler/blob/master/CHANGELOG.md#rocket-new-feature-4)
