### PR TITLE
Add section about JS bindings to JSX 4 migration guide

### DIFF
--- a/pages/docs/react/latest/migrate-react.mdx
+++ b/pages/docs/react/latest/migrate-react.mdx
@@ -240,3 +240,26 @@ module Comp = {
       </Modal>
 }
 ```
+
+
+### Bindings to JS components with optional props
+
+Previously, you could wrap optional props with an explicit `option` when writing bindings to JS components. This approach functioned only due to an implementation detail of the ppx in JSX 3; it's not how to correctly write bindings to a function with optional arguments.
+
+Rewrite this:
+
+```res
+module Button = {
+  @module("./Button") @react.component
+  external make: (~text: option<string>=?) => React.element = "default"
+}
+```
+
+To this:
+
+```res
+module Button = {
+  @module("./Button") @react.component
+  external make: (~text: string=?) => React.element = "default"
+}
+```


### PR DESCRIPTION
I found an unintended breaking change in JSX 4 for users that were relaying on a "wrong" behavior that worked only due to an implementation detail (though I'm not sure about the exact mechanism) of the ppx in V3. 

The behavior in question should be clear from my suggested changes, but feel free to look at this [Playground code](https://rescript-lang.org/try?version=v10.0.0&code=PQKgBACgTgpgbgSwPYFcDOAbAngGjAgMzC1TAEMA7CpAFzJpgBNyKwYAPBqCsjMAYyQBbAA5IKMCjTAB3BDQAWLMEhE1kPPiKiryaAFAADABQA-bap5CYAXlXrxAHjQ0oCCgHMAfDYD8hvDlFMEUYNnYRDAR+eTBDew0AkIUwyWY0BA8eGhRYfVg0FAwGZndiUgAjGHcPcgqMMJokFTUNXmwwETI0NHI4lzdPJIUkGXgYKDwMin4wgCkAZQANMAAWPH1QsAKi6QRexXpylAFKFodNDq6e5UNHBKcBmq8vQwA6fX0AFTIAazCyGAMEgkL9yNItgAhFA0JoUACinAmmjwlGYIxksjC6DCsXEyTCACJBBRCkIagJhGIJFJCWAqsCZB8AJJELYAJRgaH4bjUYAAahMMvj8VsFjBYTUDmQKipWFsuhI+KKUttMgo9r0AIwABjeWreACZkvswIwkFyKAByaSCUQIBobCow-DSc1c-BEEgnfgKSgeXEQ5q6t56vWfZkhNxMPpW2AeIpkKBW8JcTT09yMClNPqLMAEFAzC5gYzUaSA2Bkfi2qniSQ0ACUeBzaBgYRkfpoVoOqsEUFg1bA+iqfpiSEmLGYwNBvSi-2OYDQIyKjGt5cYzC2HEi0Vi8Va4ne3wUpuslB7Ry2ixWq3pMD9iHH+B7YT7A+kdbwzr20gqOnnaDCGESBEKgUCUowjSdrI3TbDA2AUiqYT6No8DIOgJYyDongNneD7IFAACE+ggMAnxCEgjBFGE0KwuIiJprwYA2GAADe+hgGAAACFFUQ0xiEm8wCcmQjAALLjjAtFwoSuFcZW1ZvHa1L1hxqbIkxQh-DAABcJamAwnB6Q8FDOK4zx+LhNheGAImKfBMDWFIzFgISkEEGQuyEvoAC+5GUdRYDSfiLHsZxwDACWADqKSsJQZb0BSnLcryNaiHWUhoHg3pgAA+uauVgA+jTNPFtD0ACvQmR84WRWAXwnr0Wn-L0rakjAUzuLMxxxgCVDleongEiEWAiMBbKqnASYIDKDTgsNXBCAAtA0cDwYEKSwK6z74BQkExmc1VqRFnGsgu5priwCUMHo5waHg+LXmAADM204puzRlpS9qOvSLrUJisTKQ6HpBEogIyEmFA1G8DZqfJMBVjQSm1jSNBqQ00jNWELFmIZNDGQeplPJ4Pi+FZNmON+cJeKx+NLV4kLwcjADyRNvAGNBRfICgACIwB5uwCbJDN2cjJMeD5jjANT4heL5nz6LxgUAMLiGSNRq+laMuexCNIyj2uqZjYDYy5xgU2pYCOPLnF244wUIki3BMfjNiEikGDAnSwC23b1uOwxGl8GAvtW5xDswnCIQcDQ7ue97od+9L8t+YrytzV8XLSKF8MZzAAlCQwLiyUOnGx8HYCcws5meHpeOx3pEt+HghbyBTi617ULFuQLnnFN5acm4VLFZy4HMSjXgweA3nDx-B3t4BbcPDy5Y-I9XXcW0AA) with code and comments that I used to experiment. 