### PR TITLE
Js.log -> Console.log

### DIFF
--- a/pages/docs/manual/latest/async-await.mdx
+++ b/pages/docs/manual/latest/async-await.mdx
@@ -39,7 +39,7 @@ let logUserDetails = async (userId: string) => {
 
   await sendAnalytics(`User details have been logged for ${userId}`)
 
-  Js.log(`Email address for user ${userId}: ${email}`)
+  Console.log(`Email address for user ${userId}: ${email}`)
 }
 ```
 
@@ -139,8 +139,8 @@ let checkAuth = async () => {
   } catch {
   | Js.Exn.Error(e) =>
     switch Js.Exn.message(e) {
-    | Some(msg) => Js.log("JS error thrown: " ++ msg)
-    | None => Js.log("Some other exception has been thrown")
+    | Some(msg) => Console.log("JS error thrown: " ++ msg)
+    | None => Console.log("Some other exception has been thrown")
     }
   }
 }
@@ -157,11 +157,11 @@ let authenticate = async () => {
 
 let checkAuth = async () => {
   switch await authenticate() {
-  | _ => Js.log("ok")
+  | _ => Console.log("ok")
   | exception Js.Exn.Error(e) => 
     switch Js.Exn.message(e) {
-    | Some(msg) => Js.log("JS error thrown: " ++ msg)
-    | None => Js.log("Some other exception has been thrown")
+    | Some(msg) => Console.log("JS error thrown: " ++ msg)
+    | None => Console.log("Some other exception has been thrown")
     }
   }
 }
@@ -181,7 +181,7 @@ This can be done by wrapping your `await` calls in a new `{}` closure.
 
 let fetchData = async () => {
   let mail = {await fetchUserMail("1234")}->Js.String2.toUpperCase
-  Js.log(`All upper-cased mail: ${mail}`)
+  Console.log(`All upper-cased mail: ${mail}`)
 }
 ```
 
@@ -208,11 +208,11 @@ Note how the original closure was removed in the final JS output. No extra alloc
 let fetchData = async () => {
   switch (await fetchUserMail("user1"), await fetchUserMail("user2")) {
   | (user1Mail, user2Mail) => {
-      Js.log("user 1 mail: " ++ user1Mail)
-      Js.log("user 2 mail: " ++ user2Mail)
+      Console.log("user 1 mail: " ++ user1Mail)
+      Console.log("user 2 mail: " ++ user2Mail)
     }
 
-  | exception JsError(err) => Js.log2("Some error occurred", err)
+  | exception JsError(err) => Console.log2("Some error occurred", err)
   }
 }
 ```
@@ -261,8 +261,8 @@ let logMultipleValues = async () => {
   let all = await Js.Promise2.all([promise1, promise2, promise3])
 
   switch all {
-  | [v1, v2, v3] => Js.log(`All values: ${v1}, ${v2}, ${v3}`)
-  | _ => Js.log("this should never happen")
+  | [v1, v2, v3] => Console.log(`All values: ${v1}, ${v2}, ${v3}`)
+  | _ => Console.log("this should never happen")
   }
 }
 ```

--- a/pages/docs/manual/latest/bind-to-global-js-values.mdx
+++ b/pages/docs/manual/latest/bind-to-global-js-values.mdx
@@ -43,7 +43,7 @@ type timerId
 @val external setTimeout: (unit => unit, int) => timerId = "setTimeout"
 @val external clearTimeout: timerId => unit = "clearTimeout"
 
-let id = setTimeout(() => Js.log("hello"), 100)
+let id = setTimeout(() => Console.log("hello"), 100)
 clearTimeout(id)
 ```
 ```js
@@ -102,8 +102,8 @@ For these troublesome global values, ReScript provides a special approach: `%ext
 
 ```res example
 switch %external(__DEV__) {
-| Some(_) => Js.log("dev mode")
-| None => Js.log("production mode")
+| Some(_) => Console.log("dev mode")
+| None => Console.log("production mode")
 }
 ```
 ```js
@@ -126,8 +126,8 @@ Another example:
 
 ```res example
 switch %external(__filename) {
-| Some(f) => Js.log(f)
-| None => Js.log("non-node environment")
+| Some(f) => Console.log(f)
+| None => Console.log("non-node environment")
 };
 ```
 ```js

--- a/pages/docs/manual/latest/bind-to-js-function.mdx
+++ b/pages/docs/manual/latest/bind-to-js-function.mdx
@@ -283,7 +283,7 @@ external on: (
 let register = rl =>
   rl
   ->on(#close(event => ()))
-  ->on(#line(line => Js.log(line)));
+  ->on(#line(line => Console.log(line)));
 ```
 ```js
 function register(rl) {
@@ -313,7 +313,7 @@ external processOnExit: (
 ) => unit = "process.on"
 
 processOnExit(exitCode =>
-  Js.log("error code: " ++ Js.Int.toString(exitCode))
+  Console.log("error code: " ++ Js.Int.toString(exitCode))
 );
 ```
 ```js
@@ -365,7 +365,7 @@ type x
 @val external x: x = "x"
 @set external setOnload: (x, @this ((x, int) => unit)) => unit = "onload"
 @get external resp: x => int = "response"
-setOnload(x, @this (o, v) => Js.log(resp(o) + v))
+setOnload(x, @this (o, v) => Console.log(resp(o) + v))
 ```
 ```js
 x.onload = function (v) {

--- a/pages/docs/manual/latest/bind-to-js-object.mdx
+++ b/pages/docs/manual/latest/bind-to-js-object.mdx
@@ -143,7 +143,7 @@ type t
 
 let i32arr = create(3)
 i32arr->set(0, 42)
-Js.log(i32arr->get(0))
+Console.log(i32arr->get(0))
 ```
 ```js
 var i32arr = new Int32Array(3);

--- a/pages/docs/manual/latest/build-external-stdlib.mdx
+++ b/pages/docs/manual/latest/build-external-stdlib.mdx
@@ -42,7 +42,7 @@ Now the compiled JS code will import using the path defined by `external-stdlib`
 <CodeTab labels={["ReScript", "JS output"]}>
 
 ```res
-Array.forEach([1, 2, 3], num => Js.log(num))
+Array.forEach([1, 2, 3], num => Console.log(num))
 ```
 
 ```js

--- a/pages/docs/manual/latest/control-flow.mdx
+++ b/pages/docs/manual/latest/control-flow.mdx
@@ -98,7 +98,7 @@ For loops iterate from a starting value up to (and including) the ending value.
 
 ```res
 for i in startValueInclusive to endValueInclusive {
-  Js.log(i)
+  Console.log(i)
 }
 ```
 ```js
@@ -114,7 +114,7 @@ for(var i = startValueInclusive; i <= endValueInclusive; ++i){
 ```res example
 // prints: 1 2 3, one per line
 for x in 1 to 3 {
-  Js.log(x)
+  Console.log(x)
 }
 ```
 ```js
@@ -131,7 +131,7 @@ You can make the `for` loop count in the opposite direction by using `downto`.
 
 ```res
 for i in startValueInclusive downto endValueInclusive {
-  Js.log(i)
+  Console.log(i)
 }
 ```
 ```js
@@ -147,7 +147,7 @@ for(var i = startValueInclusive; i >= endValueInclusive; --i){
 ```res example
 // prints: 3 2 1, one per line
 for x in 3 downto 1 {
-  Js.log(x)
+  Console.log(x)
 }
 ```
 ```js
@@ -190,7 +190,7 @@ while !break.contents {
   if Js.Math.random() > 0.3 {
     break := true
   } else {
-    Js.log("Still running")
+    Console.log("Still running")
   }
 }
 ```

--- a/pages/docs/manual/latest/embed-raw-javascript.mdx
+++ b/pages/docs/manual/latest/embed-raw-javascript.mdx
@@ -47,7 +47,7 @@ let add = %raw(`
   }
 `)
 
-Js.log(add(1, 2))
+Console.log(add(1, 2))
 ```
 ```js
 var add = function(a, b) {

--- a/pages/docs/manual/latest/exception.mdx
+++ b/pages/docs/manual/latest/exception.mdx
@@ -66,8 +66,8 @@ You can directly match on exceptions _while_ getting another return value from a
 
 ```res prelude
 switch list{1, 2, 3}->List.getExn(4) {
-| item => Js.log(item)
-| exception Not_found => Js.log("No such item found!")
+| item => Console.log(item)
+| exception Not_found => Console.log("No such item found!")
 }
 ```
 ```js
@@ -160,7 +160,7 @@ try {
 } catch {
 | Js.Exn.Error(obj) =>
   switch Js.Exn.message(obj) {
-  | Some(m) => Js.log("Caught a JS exception! Message: " ++ m)
+  | Some(m) => Console.log("Caught a JS exception! Message: " ++ m)
   | None => ()
   }
 }

--- a/pages/docs/manual/latest/extensible-variant.mdx
+++ b/pages/docs/manual/latest/extensible-variant.mdx
@@ -48,10 +48,10 @@ Extensible variants are open-ended, so the compiler will not be able to exhausti
 ```res
 let print = v =>
   switch v {
-  | Point(x, y) => Js.log2("Point", (x, y))
-  | Line(ax, ay, bx, by) => Js.log2("Line", (ax, ay, bx, by))
+  | Point(x, y) => Console.log2("Point", (x, y))
+  | Line(ax, ay, bx, by) => Console.log2("Line", (ax, ay, bx, by))
   | Other
-  | _ => Js.log("Other")
+  | _ => Console.log("Other")
   }
 ```
 ```js

--- a/pages/docs/manual/latest/external.mdx
+++ b/pages/docs/manual/latest/external.mdx
@@ -51,7 +51,7 @@ Once declared, you can use an `external` as a normal value, just like a let bind
 
 // call a method
 document["addEventListener"](."mouseup", _event => {
-  Js.log("clicked!")
+  Console.log("clicked!")
 })
 
 // get a property

--- a/pages/docs/manual/latest/generate-converters-accessors.mdx
+++ b/pages/docs/manual/latest/generate-converters-accessors.mdx
@@ -91,7 +91,7 @@ let pets = [{name: "bob"}, {name: "bob2"}]
 pets
  ->Array.map(name)
  ->Array.joinWith("&")
- ->Js.log
+ ->Console.log
 ```
 
 ```js

--- a/pages/docs/manual/latest/import-from-export-to-js.mdx
+++ b/pages/docs/manual/latest/import-from-export-to-js.mdx
@@ -84,7 +84,7 @@ Use the value `"default"` on the right hand side:
 
 ```res example
 @module("./student") external studentName: string = "default"
-Js.log(studentName)
+Console.log(studentName)
 ```
 ```js
 import Student from "./student";

--- a/pages/docs/manual/latest/inlining-constants.mdx
+++ b/pages/docs/manual/latest/inlining-constants.mdx
@@ -34,7 +34,7 @@ So, in ReScript, producing that example `if (process.env.mode === 'development')
 let mode = "development"
 
 if (process["env"]["mode"] === mode) {
-  Js.log("Dev-only code here!")
+  Console.log("Dev-only code here!")
 }
 ```
 ```js
@@ -58,7 +58,7 @@ The JS output shows `if (process.env.mode === mode)`, which isn't what we wanted
 let mode = "development"
 
 if (process["env"]["mode"] === mode) {
-  Js.log("Dev-only code here!")
+  Console.log("Dev-only code here!")
 }
 ```
 ```js

--- a/pages/docs/manual/latest/interop-cheatsheet.mdx
+++ b/pages/docs/manual/latest/interop-cheatsheet.mdx
@@ -159,7 +159,7 @@ var result3 = Caml_option.nullable_to_opt(10);
 [1, 2, 3]
   ->map(a => a + 1)
   ->filter(a => mod(a, 2) == 0)
-  ->Js.log
+  ->Console.log
 ```
 ```js
 console.log(

--- a/pages/docs/manual/latest/json.mdx
+++ b/pages/docs/manual/latest/json.mdx
@@ -39,7 +39,7 @@ Use `Js.Json.stringify`:
 <CodeTab labels={["ReScript", "JS Output"]}>
 
 ```res example
-Js.log(Js.Json.stringifyAny(["Amy", "Joe"]))
+Console.log(Js.Json.stringifyAny(["Amy", "Joe"]))
 ```
 ```js
 console.log(JSON.stringify([

--- a/pages/docs/manual/latest/lazy-values.mdx
+++ b/pages/docs/manual/latest/lazy-values.mdx
@@ -16,7 +16,7 @@ external readdirSync: string => array<string> = "readdirSync"
 
 // Read the directory, only once
 let expensiveFilesRead = lazy({
-  Js.log("Reading dir")
+  Console.log("Reading dir")
   readdirSync("./pages")
 })
 ```
@@ -46,10 +46,10 @@ To actually run the lazy value's computation, use `Lazy.force` from the globally
 
 ```res example
 // First call. The computation happens
-Js.log(Lazy.force(expensiveFilesRead)) // logs "Reading dir" and the directory content
+Console.log(Lazy.force(expensiveFilesRead)) // logs "Reading dir" and the directory content
 
 // Second call. Will just return the already calculated result
-Js.log(Lazy.force(expensiveFilesRead)) // logs the directory content
+Console.log(Lazy.force(expensiveFilesRead)) // logs the directory content
 ```
 ```js
 console.log(CamlinternalLazy.force(expensiveFilesRead));
@@ -69,7 +69,7 @@ Instead of using `Lazy.force`, you can also use [pattern matching](pattern-match
 
 ```res example
 switch expensiveFilesRead {
-| lazy(result) => Js.log(result)
+| lazy(result) => Console.log(result)
 }
 ```
 ```js
@@ -84,7 +84,7 @@ Since pattern matching also works on a `let` binding, you can also do:
 
 ```res example
 let lazy(result) = expensiveFilesRead
-Js.log(result)
+Console.log(result)
 ```
 ```js
 var result = CamlinternalLazy.force(expensiveFilesRead);

--- a/pages/docs/manual/latest/let-binding.mdx
+++ b/pages/docs/manual/latest/let-binding.mdx
@@ -54,7 +54,7 @@ ReScript's `if`, `while` and functions all use the same block scoping mechanism.
 ```res
 if displayGreeting {
   let message = "Enjoying the docs so far?"
-  Js.log(message)
+  Console.log(message)
 }
 // `message` not accessible here!
 ```

--- a/pages/docs/manual/latest/module.mdx
+++ b/pages/docs/manual/latest/module.mdx
@@ -55,7 +55,7 @@ using the `.` notation. This demonstrates modules' utility for namespacing.
 
 ```res
 let anotherPerson: School.profession = School.Teacher
-Js.log(School.getProfession(anotherPerson)) /* "A teacher" */
+Console.log(School.getProfession(anotherPerson)) /* "A teacher" */
 ```
 ```js
 var anotherPerson = /* Teacher */0;

--- a/pages/docs/manual/latest/newcomer-examples.mdx
+++ b/pages/docs/manual/latest/newcomer-examples.mdx
@@ -21,8 +21,8 @@ let possiblyNullValue1 = None
 let possiblyNullValue2 = Some("Hello")
 
 switch possiblyNullValue2 {
-| None => Js.log("Nothing to see here.")
-| Some(message) => Js.log(message)
+| None => Console.log("Nothing to see here.")
+| Some(message) => Console.log(message)
 }
 ```
 ```js

--- a/pages/docs/manual/latest/null-undefined-option.mdx
+++ b/pages/docs/manual/latest/null-undefined-option.mdx
@@ -67,9 +67,9 @@ Later on, when another piece of code receives such value, it'd be forced to hand
 ```res
 switch licenseNumber {
 | None =>
-  Js.log("The person doesn't have a car")
+  Console.log("The person doesn't have a car")
 | Some(number) =>
-  Js.log("The person's license number is " ++ Js.Int.toString(number))
+  Console.log("The person's license number is " ++ Js.Int.toString(number))
 }
 ```
 ```js

--- a/pages/docs/manual/latest/object.mdx
+++ b/pages/docs/manual/latest/object.mdx
@@ -173,7 +173,7 @@ Since objects don't require type declarations, and since ReScript infers all the
 
 // call a method
 document["addEventListener"](. "mouseup", _event => {
-  Js.log("clicked!")
+  Console.log("clicked!")
 })
 
 // get a property

--- a/pages/docs/manual/latest/pattern-matching-destructuring.mdx
+++ b/pages/docs/manual/latest/pattern-matching-destructuring.mdx
@@ -23,7 +23,7 @@ Even JavaScript has destructuring, which is "opening up" a data structure to ext
 ```res example
 let coordinates = (10, 20, 30)
 let (x, _, _) = coordinates
-Js.log(x) // 10
+Console.log(x) // 10
 ```
 ```js
 var coordinates = [10, 20, 30];
@@ -101,7 +101,7 @@ type result =
 let displayMessage = (Success(m)) => {
   // we've directly extracted the success message
   // string by destructuring the parameter
-  Js.log(m)
+  Console.log(m)
 }
 displayMessage(Success("You did it!"))
 ```
@@ -174,11 +174,11 @@ In other languages, you'd end up with a series of if-elses that are hard to read
 let data = GoodResult("Product shipped!")
 switch data {
 | GoodResult(theMessage) =>
-  Js.log("Success! " ++ theMessage)
+  Console.log("Success! " ++ theMessage)
 | BadResult(errorCode) =>
-  Js.log("Something's wrong. The error code is: " ++ Js.Int.toString(errorCode))
+  Console.log("Something's wrong. The error code is: " ++ Js.Int.toString(errorCode))
 | NoResult =>
-  Js.log("Bah.")
+  Console.log("Bah.")
 }
 ```
 ```js
@@ -341,9 +341,9 @@ let myStatus = Vacations(10)
 
 switch myStatus {
 | Vacations(days)
-| Sabbatical(days) => Js.log(`Come back in ${Js.Int.toString(days)} days!`)
+| Sabbatical(days) => Console.log(`Come back in ${Js.Int.toString(days)} days!`)
 | Sick
-| Present => Js.log("Hey! How are you?")
+| Present => Console.log("Hey! How are you?")
 }
 ```
 ```js
@@ -371,8 +371,8 @@ If you have a value like `Teacher(payload)` where you just want to pattern match
 
 ```res example
 switch person1 {
-| Teacher(_) => Js.log("Hi teacher")
-| Student(_) => Js.log("Hey student")
+| Teacher(_) => Console.log("Hi teacher")
+| Student(_) => Console.log("Hey student")
 }
 ```
 ```js
@@ -391,8 +391,8 @@ if (person1.TAG) {
 
 ```res example
 switch myStatus {
-| Vacations(_) => Js.log("Have fun!")
-| _ => Js.log("Ok.")
+| Vacations(_) => Console.log("Have fun!")
+| _ => Console.log("Ok.")
 }
 ```
 ```js
@@ -411,8 +411,8 @@ if (typeof myStatus === "number" || myStatus.TAG) {
 
 ```res example
 switch myStatus {
-| Vacations(_) => Js.log("Have fun!")
-| Sabbatical(_) | Sick | Present => Js.log("Ok.")
+| Vacations(_) => Console.log("Have fun!")
+| Sabbatical(_) | Sick | Present => Console.log("Ok.")
 }
 ```
 ```js
@@ -438,9 +438,9 @@ switch person1 {
 | Teacher(_) => () // do nothing
 | Student({reportCard: {gpa}}) =>
   if gpa < 0.5 {
-    Js.log("What's happening")
+    Console.log("What's happening")
   } else {
-    Js.log("Heyo")
+    Console.log("Heyo")
   }
 }
 ```
@@ -464,10 +464,10 @@ if (person1.TAG) {
 switch person1 {
 | Teacher(_) => () // do nothing
 | Student({reportCard: {gpa}}) if gpa < 0.5 =>
-  Js.log("What's happening")
+  Console.log("What's happening")
 | Student(_) =>
   // fall-through, catch-all case
-  Js.log("Heyo")
+  Console.log("Heyo")
 }
 ```
 ```js
@@ -492,8 +492,8 @@ If the function throws an exception (covered later), you can also match on _that
 
 ```res
 switch List.find(i => i === theItem, myItems) {
-| item => Js.log(item)
-| exception Not_found => Js.log("No such item found!")
+| item => Console.log(item)
+| exception Not_found => Console.log("No such item found!")
 }
 ```
 ```js
@@ -530,12 +530,12 @@ if (exit === 1) {
 ```res example
 let students = ["Jane", "Harvey", "Patrick"]
 switch students {
-| [] => Js.log("There are no students")
+| [] => Console.log("There are no students")
 | [student1] =>
-  Js.log("There's a single student here: " ++ student1)
+  Console.log("There's a single student here: " ++ student1)
 | manyStudents =>
   // display the array of names
-  Js.log2("The students are: ", manyStudents)
+  Console.log2("The students are: ", manyStudents)
 }
 ```
 ```js
@@ -567,9 +567,9 @@ Pattern matching on list is similar to array, but with the extra feature of extr
 let rec printStudents = (students) => {
   switch students {
   | list{} => () // done
-  | list{student} => Js.log("Last student: " ++ student)
+  | list{student} => Console.log("Last student: " ++ student)
   | list{student1, ...otherStudents} =>
-    Js.log(student1)
+    Console.log(student1)
     printStudents(otherStudents)
   }
 }
@@ -619,7 +619,7 @@ printStudents({
 let coordinates = (10, 20, 30)
 let centerY = 20
 switch coordinates {
-| (x, _centerY, _) => Js.log(x)
+| (x, _centerY, _) => Console.log(x)
 }
 ```
 ```js
@@ -715,8 +715,8 @@ Some({name: ""})
 let myNullableValue = Some(5)
 
 switch myNullableValue {
-| Some(_v) => Js.log("value is present")
-| None => Js.log("value is absent")
+| Some(_v) => Console.log("value is present")
+| None => Console.log("value is absent")
 }
 ```
 ```js

--- a/pages/docs/manual/latest/polymorphic-variant.mdx
+++ b/pages/docs/manual/latest/polymorphic-variant.mdx
@@ -54,9 +54,9 @@ These types can also be inlined, unlike for regular variant:
 ```res
 let render = (myColor: [#red | #green | #blue]) => {
   switch myColor {
-  | #blue => Js.log("Hello blue!")
+  | #blue => Console.log("Hello blue!")
   | #red
-  | #green => Js.log("Hello other colors")
+  | #green => Console.log("Hello other colors")
   }
 }
 ```
@@ -82,10 +82,10 @@ type color = [#red | #green | #blue]
 
 let render = myColor => {
   switch myColor {
-  | #blue => Js.log("Hello blue!")
-  | #green => Js.log("Hello green!")
+  | #blue => Console.log("Hello blue!")
+  | #green => Console.log("Hello green!")
   // works!
-  | #yellow => Js.log("Hello yellow!")
+  | #yellow => Console.log("Hello yellow!")
   }
 }
 ```
@@ -171,9 +171,9 @@ There's also some special [pattern matching](./pattern-matching-destructuring) s
 // Continuing the previous example above...
 
 switch myColor {
-| #...blue => Js.log("This blue-ish")
-| #...red => Js.log("This red-ish")
-| other => Js.log2("Other color than red and blue: ", other)
+| #...blue => Console.log("This blue-ish")
+| #...red => Console.log("This red-ish")
+| other => Console.log2("Other color than red and blue: ", other)
 }
 ```
 
@@ -195,9 +195,9 @@ This is a shorter version of:
 
 ```res
 switch myColor {
-| #Sapphire | #Neon | #Navy => Js.log("This is blue-ish")
-| #Ruby | #Redwood | #Rust => Js.log("This is red-ish")
-| other => Js.log2("Other color than red and blue: ", other)
+| #Sapphire | #Neon | #Navy => Console.log("This is blue-ish")
+| #Ruby | #Redwood | #Rust => Console.log("This is red-ish")
+| other => Console.log2("Other color than red and blue: ", other)
 }
 ```
 
@@ -221,7 +221,7 @@ let displayColor = v => {
   }
 }
 
-Js.log(displayColor(myColor))
+Console.log(displayColor(myColor))
 ```
 
 ```js
@@ -424,8 +424,8 @@ One might think that polymorphic variants are superior to regular [variants](./v
   let myColor = #red
 
   switch myColor {
-  | #red => Js.log("Hello red!")
-  | #blue => Js.log("Hello blue!")
+  | #red => Console.log("Hello red!")
+  | #blue => Console.log("Hello blue!")
   }
   ```
   Because there's no poly variant definition, it's hard to know whether the `#blue` case can be safely removed.

--- a/pages/docs/manual/latest/promise.mdx
+++ b/pages/docs/manual/latest/promise.mdx
@@ -59,7 +59,7 @@ let logAsyncMessage = () => {
     resolve("Message: " ++ msg)
   })
   ->then(msg => {
-    Js.log(msg)
+    Console.log(msg)
 
     // Even if there is no result, we need to use resolve() to return a promise
     resolve()
@@ -73,7 +73,7 @@ For comparison, the `async` / `await` version of the same code would look like t
 ```res
 let logAsyncMessage = async () => {
   let msg = await Js.Promise2.resolve("hello world")
-  Js.log(`Message: ${msg}`)
+  Console.log(`Message: ${msg}`)
 }
 ```
 
@@ -93,7 +93,7 @@ external fetchMessage: string => promise<string> = "global.fetchMessage"
 let logAsyncMessage = async () => {
   let messages = await Js.Promise2.all([fetchMessage("message1"), fetchMessage("message2")])
 
-  Js.log(Js.Array2.joinWith(messages, ", "))
+  Console.log(Js.Array2.joinWith(messages, ", "))
 }
 ```
 
@@ -147,13 +147,13 @@ Using the [pipe operator](pipe.md):
 let myPromise = Js.Promise.make((~resolve, ~reject) => resolve(. 2))
 
 myPromise->Js.Promise.then_(value => {
-  Js.log(value)
+  Console.log(value)
   Js.Promise.resolve(value + 2)
 }, _)->Js.Promise.then_(value => {
-  Js.log(value)
+  Console.log(value)
   Js.Promise.resolve(value + 3)
 }, _)->Js.Promise.catch(err => {
-  Js.log2("Failure!!", err)
+  Console.log2("Failure!!", err)
   Js.Promise.resolve(-2)
 }, _)
 ```

--- a/pages/docs/manual/latest/variant.mdx
+++ b/pages/docs/manual/latest/variant.mdx
@@ -776,9 +776,9 @@ There's a linear amount of branch checking here (`O(n)`). Compare this to using 
 type animal = Dog | Cat | Bird
 let data = Dog
 switch data {
-| Dog => Js.log("Wof")
-| Cat => Js.log("Meow")
-| Bird => Js.log("Kashiiin")
+| Dog => Console.log("Wof")
+| Cat => Console.log("Meow")
+| Bird => Console.log("Kashiiin")
 }
 ```
 ```js


### PR DESCRIPTION
Use `Console.log` from Core instead of `Js.log` in the docs/examples.

(Except for the `Js` docs and `Belt` docs which I left untouched.)