### PR TITLE
Footer: change "Team" link to "Community"

### DIFF
--- a/src/components/Footer.res
+++ b/src/components/Footer.res
@@ -46,8 +46,8 @@ let make = () => {
         <Section title="About">
           <ul className="text-16 text-gray-80-tr space-y-2">
             <li>
-              <Next.Link href="/community#core-team" className={linkClass}>
-                {React.string("Team")}
+              <Next.Link href="/community" className={linkClass}>
+                {React.string("Community")}
               </Next.Link>
             </li>
             <li>


### PR DESCRIPTION
As there is no more "Core Team" section on the community page.