### PR TITLE
String2, Array2, Promise2 -> Core

### DIFF
--- a/pages/docs/manual/latest/array-and-list.mdx
+++ b/pages/docs/manual/latest/array-and-list.mdx
@@ -25,8 +25,6 @@ ReScript arrays' items must have the same type, i.e. homogeneous.
 
 ### Usage
 
-See the [Js.Array](api/js/array) API.
-
 Access & update an array item like so:
 
 <CodeTab labels={["ReScript", "JS Output"]}>
@@ -38,7 +36,7 @@ let firstItem = myArray[0] // "hello"
 
 myArray[0] = "hey" // now ["hey", "world", "how are you"]
 
-let pushedValue = Js.Array2.push(myArray, "bye")
+myArray->Array.push("bye")
 ```
 ```js
 var myArray = ["hello", "world", "how are you"];

--- a/pages/docs/manual/latest/async-await.mdx
+++ b/pages/docs/manual/latest/async-await.mdx
@@ -180,7 +180,7 @@ This can be done by wrapping your `await` calls in a new `{}` closure.
 @val external fetchUserMail: string => promise<string> = "GlobalAPI.fetchUserMail"
 
 let fetchData = async () => {
-  let mail = {await fetchUserMail("1234")}->Js.String2.toUpperCase
+  let mail = {await fetchUserMail("1234")}->String.toUpperCase
   Console.log(`All upper-cased mail: ${mail}`)
 }
 ```
@@ -242,13 +242,13 @@ async function fetchData(param) {
 
 ## `await` multiple promises
 
-We can utilize the `Js.Promise2` module to handle multiple promises. E.g. let's use `Js.Promise2.all` to wait for multiple promises before continuing the program:
+We can utilize the `Promise` module to handle multiple promises. E.g. let's use `Promise.all` to wait for multiple promises before continuing the program:
 
 ```res
 let pauseReturn = (value, timeout) => {
-  Js.Promise2.make((~resolve, ~reject) => {
+  Promise.make((resolve, _reject) => {
     Js.Global.setTimeout(() => {
-      resolve(. value)
+      resolve(value)
     }, timeout)->ignore
   })
 }
@@ -258,7 +258,7 @@ let logMultipleValues = async () => {
   let promise2 = pauseReturn("value2", 1200)
   let promise3 = pauseReturn("value3", 500)
 
-  let all = await Js.Promise2.all([promise1, promise2, promise3])
+  let all = await Promise.all([promise1, promise2, promise3])
 
   switch all {
   | [v1, v2, v3] => Console.log(`All values: ${v1}, ${v2}, ${v3}`)

--- a/pages/docs/manual/latest/promise.mdx
+++ b/pages/docs/manual/latest/promise.mdx
@@ -93,7 +93,7 @@ external fetchMessage: string => promise<string> = "global.fetchMessage"
 let logAsyncMessage = async () => {
   let messages = await Js.Promise2.all([fetchMessage("message1"), fetchMessage("message2")])
 
-  Console.log(Js.Array2.joinWith(messages, ", "))
+  Console.log(messages->Array.joinWith(", "))
 }
 ```
 


### PR DESCRIPTION
Get rid of Js.String2, Js.Array2, Js.Promise2 usages.

Except in the Js and Promise docs themselves.
The Promise docs should be changed to point to Core once the Core docs are merged.