### PR TITLE
fix typo: Core Std -> Core Stdlib

### DIFF
--- a/src/layouts/ApiOverviewLayout.res
+++ b/src/layouts/ApiOverviewLayout.res
@@ -6,11 +6,11 @@ let categories: array<Sidebar.Category.t> = [
     items: [{name: "Overview", href: "/docs/manual/latest/api"}],
   },
   {
-    name: "Core Std",
+    name: "Core Stdlib",
     items: [{name: "Core Stdlib", href: "/docs/manual/latest/api/core"}],
   },
   {
-    name: "Modules",
+    name: "Other Modules",
     items: [
       {name: "Js Module", href: "/docs/manual/latest/api/js"},
       {name: "Belt Stdlib", href: "/docs/manual/latest/api/belt"},


### PR DESCRIPTION
![image](https://github.com/rescript-association/rescript-lang.org/assets/16160544/45c6535c-97d6-4b20-9e5f-0f0002075f92)
