### PR TITLE
Update GitHub links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Please make sure to check out our [Code of Conduct](CODE_OF_CONDUCT.md) and make
 
 ## Ways to contribute
 
-- Writing docs for the manual (Check for issues that are marked with a [`manual`](https://github.com/reason-association/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"manual") and [`help wanted`](https://github.com/reason-association/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted") tag)
-- Joining in discussions on our [issue tracker](https://github.com/reason-association/rescript-lang.org/issues)
+- Writing docs for the manual (Check for issues that are marked with a [`manual`](https://github.com/rescript-association/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"manual") and [`help wanted`](https://github.com/rescript-association/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted") tag)
+- Joining in discussions on our [issue tracker](https://github.com/rescript-association/rescript-lang.org/issues)
 - Give feedback for improvements (incomplete / missing docs, bad wording,
   search user experience / design, etc.)
 - Advanced: Help building platform features (design system, automatic testing, markdown parsing, etc.)
@@ -16,7 +16,7 @@ Please make sure to check out our [Code of Conduct](CODE_OF_CONDUCT.md) and make
 
 ### Find an issue
 
-Before you start any work or submit any PRs, make sure to check our [issue tracker](https://github.com/reason-association/rescript-lang.org/issues) for any issues or discussions on the topic.
+Before you start any work or submit any PRs, make sure to check our [issue tracker](https://github.com/rescript-association/rescript-lang.org/issues) for any issues or discussions on the topic.
 
 If you can't find any relevant issues, feel free to create a new one to start a discussion. We usually assign issues to a responsible person to prevent confusion and duplicate work, so always double check if an issue is currently being worked on, or talk to the current assignee to take over the task.
 
@@ -24,7 +24,7 @@ If you can't find any relevant issues, feel free to create a new one to start a 
 
 The project follows very specific goals and tries to deliver the highest value with the least amount of resources. Please help us focus on the tasks at hand and don't submit any code / bigger refactorings without any proper discussion on the issue tracker. Otherwise your PR might not be accepted!
 
-If you need inspiration on what to work on, you can check out issues tagged with [`good first issue`](https://github.com/reason-association/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"good+first+issue") or [`help wanted`](https://github.com/reason-association/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted").
+If you need inspiration on what to work on, you can check out issues tagged with [`good first issue`](https://github.com/rescript-association/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"good+first+issue") or [`help wanted`](https://github.com/rescript-association/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted").
 
 ### Discuss an issue
 
@@ -44,7 +44,7 @@ We value your voluntary work, and of course it's fine to step back from a ticket
 
 ### Communication Channels
 
-- [Issue Tracker](https://github.com/reason-association/rescript-lang.org/issues)
+- [Issue Tracker](https://github.com/rescript-association/rescript-lang.org/issues)
 - [ReScript Discourse (General / mostly unrelated discussions)](http://forum.rescript-lang.org)
 
 ## Working on the rescript-lang.org
@@ -55,7 +55,7 @@ We try to keep our contribution guidelines to a minimum. Please keep following r
 
 The less code we write, the better. If there's a way to do rendering on the server, or enhance existing markdown files, we prefer that over client-side rendering and external loading.
 
-We also try to keep our third-party dependencies to a minimum. We use specific frameworks to make things work (`unified`, `remark`, `mdx`, `bs-platform`, etc).  Please try to keep a small JS footprint, especially for client side code (to keep the bundle size small).
+We also try to keep our third-party dependencies to a minimum. We use specific frameworks to make things work (`unified`, `remark`, `mdx`, `bs-platform`, etc). Please try to keep a small JS footprint, especially for client side code (to keep the bundle size small).
 
 ### Think about the target audience & UX
 
@@ -72,7 +72,7 @@ Always check if there are any designs for certain UI components and think about 
 
 ### Tailwind for CSS Development
 
-We use [TailwindCSS](https://tailwindcss.com) for our component styling. Check out the [tailwind.config.js](tailwind.config.js) file for configured tailwind features, colors, border-radius values etc..  If you are not familiar with Tailwind, check out existing components for inspiration.
+We use [TailwindCSS](https://tailwindcss.com) for our component styling. Check out the [tailwind.config.js](tailwind.config.js) file for configured tailwind features, colors, border-radius values etc.. If you are not familiar with Tailwind, check out existing components for inspiration.
 
 We sometimes also need to fall back to common css (with tailwind `@apply` directives to enforce our style system). You can find the CSS main entrypoint in [styles/main.css](styles/main.css).
 

--- a/_blogposts/2020-11-17-editor-support-custom-operators-and-more.mdx
+++ b/_blogposts/2020-11-17-editor-support-custom-operators-and-more.mdx
@@ -28,7 +28,7 @@ Hongbo continues to improve the compiler experience in monorepo-like setups. Exp
 
 ## Docs
 
-Patrick is [rearranging the React documentation](https://github.com/reason-association/rescript-lang.org/pull/96), and continues to improve the main documentation site with Cheng Lou.
+Patrick is [rearranging the React documentation](https://github.com/rescript-association/rescript-lang.org/pull/96), and continues to improve the main documentation site with Cheng Lou.
 
 ## Syntax
 

--- a/pages/blogpost-guide.mdx
+++ b/pages/blogpost-guide.mdx
@@ -7,7 +7,7 @@ on rescript-lang.org.
 
 ## Requirements
 
-Clone the [rescript-lang.org repo](https://github.com/reason-association/rescript-lang.org) and follow the README instructions to run the local development server.
+Clone the [rescript-lang.org repo](https://github.com/rescript-association/rescript-lang.org) and follow the README instructions to run the local development server.
 
 Open the [localhost:3000/blog](/blog) page to see the blog page.
 

--- a/pages/docs/guidelines/publishing-packages.mdx
+++ b/pages/docs/guidelines/publishing-packages.mdx
@@ -26,4 +26,4 @@ Our package index will pick up the newest npm packages two times a day, so it mi
 
 We also maintain a hand-curated index of different resources that are not necessarily released on npm, such as plain URLs to independent files / repositories, or GitHub gists.
 
-You can submit your own resource by editing rescript-lang.org's [resource json file](https://github.com/reason-association/rescript-lang.org/blob/master/data/packages_url_resources.json) file and submit a PR.
+You can submit your own resource by editing rescript-lang.org's [resource json file](https://github.com/rescript-association/rescript-lang.org/blob/master/data/packages_url_resources.json) file and submit a PR.

--- a/pages/docs/react/latest/introduction.mdx
+++ b/pages/docs/react/latest/introduction.mdx
@@ -27,4 +27,4 @@ All our documented examples can be compiled in our [ReScript Playground](/try) a
 ## Development
 
 - In case you are having any issues or if you want to help us out improving our bindings, check out our [rescript-react GitHub repository](https://github.com/rescript-lang/rescript-react).
-- For doc related issues, please go to the [rescript-lang.org repo](https://github.com/reason-association/rescript-lang.org).
+- For doc related issues, please go to the [rescript-lang.org repo](https://github.com/rescript-association/rescript-lang.org).

--- a/pages/docs/react/v0.10.0/introduction.mdx
+++ b/pages/docs/react/v0.10.0/introduction.mdx
@@ -27,4 +27,4 @@ All our documented examples can be compiled in our [ReScript Playground](/try) a
 ## Development
 
 - In case you are having any issues or if you want to help us out improving our bindings, check out our [rescript-react GitHub repository](https://github.com/rescript-lang/rescript-react).
-- For doc related issues, please go to the [rescript-lang.org repo](https://github.com/reason-association/rescript-lang.org).
+- For doc related issues, please go to the [rescript-lang.org repo](https://github.com/rescript-association/rescript-lang.org).

--- a/pages/docs/react/v0.11.0/introduction.mdx
+++ b/pages/docs/react/v0.11.0/introduction.mdx
@@ -27,4 +27,4 @@ All our documented examples can be compiled in our [ReScript Playground](/try) a
 ## Development
 
 - In case you are having any issues or if you want to help us out improving our bindings, check out our [rescript-react GitHub repository](https://github.com/rescript-lang/rescript-react).
-- For doc related issues, please go to the [rescript-lang.org repo](https://github.com/reason-association/rescript-lang.org).
+- For doc related issues, please go to the [rescript-lang.org repo](https://github.com/rescript-association/rescript-lang.org).

--- a/src/DocsOverview.res
+++ b/src/DocsOverview.res
@@ -37,7 +37,7 @@ let default = (~showVersionSelect=true) => {
     ("Package Index", "/packages"),
     ("rescript-react", "/docs/react/latest/introduction"),
     ("GenType", "/docs/manual/latest/typescript-integration"),
-    ("Reanalyze", "https://github.com/reason-association/reanalyze"),
+    ("Reanalyze", "https://github.com/rescript-association/reanalyze"),
   ]
 
   let tools = [("Syntax Lookup", "/syntax-lookup")]

--- a/src/common/Constants.res
+++ b/src/common/Constants.res
@@ -21,7 +21,7 @@ let ecosystem = [
   ("Package Index", "/packages"),
   ("rescript-react", "/docs/react/latest/introduction"),
   ("GenType", "/docs/manual/latest/typescript-integration"),
-  ("Reanalyze", "https://github.com/reason-association/reanalyze"),
+  ("Reanalyze", "https://github.com/rescript-association/reanalyze"),
 ]
 
 let tools = [("Syntax Lookup", "/syntax-lookup")]

--- a/src/components/Navigation.res
+++ b/src/components/Navigation.res
@@ -16,7 +16,7 @@ let linkOrActiveApiSubroute = (~route) => {
   }
 }
 
-let githubHref = "https://github.com/reason-association/rescript-lang.org#rescript-langorg"
+let githubHref = "https://github.com/rescript-lang/rescript-compiler"
 //let twitterHref = "https://twitter.com/rescriptlang"
 let discourseHref = "https://forum.rescript-lang.org"
 
@@ -202,7 +202,7 @@ module DocsSection = {
         imgSrc: "/static/ic_reanalyze@2x.png",
         title: "Reanalyze",
         description: "Dead Code & Termination analysis",
-        href: "https://github.com/reason-association/reanalyze",
+        href: "https://github.com/rescript-association/reanalyze",
         isActive: _ => {
           false
         },

--- a/src/layouts/DocsLayout.res
+++ b/src/layouts/DocsLayout.res
@@ -139,7 +139,7 @@ let make = (
 
       let ghEditHref = switch canonical {
       | Some(canonical) =>
-        `https://github.com/reason-association/rescript-lang.org/blob/master/pages${canonical}.mdx`->Some
+        `https://github.com/rescript-association/rescript-lang.org/blob/master/pages${canonical}.mdx`->Some
       | None => None
       }
       (meta, ghEditHref)


### PR DESCRIPTION
There are still some links to the old `reason-association` name in the block posts left. Should I update them to `rescript-association` as well?