### PR TITLE
Fix typo

### DIFF
--- a/pages/docs/manual/latest/converting-from-js.mdx
+++ b/pages/docs/manual/latest/converting-from-js.mdx
@@ -279,7 +279,7 @@ exports.queryResult = queryResult;
 </CodeTab>
 
 We've:
-- introduced an opaque types for `school` and `student` to prevent misusages their values
+- introduced an opaque types for `school` and `student` to prevent misuse of their values
 - typed the payload as a record with only the `student` field
 - typed `getStudentById` as the sole method of `student`
 


### PR DESCRIPTION
"prevent misusages their values" → "prevent misuse of their values"