### PR TITLE
Responsive Docs Menu API "Types and values"

### DIFF
--- a/src/ApiDocs.res
+++ b/src/ApiDocs.res
@@ -341,14 +341,15 @@ let default = (props: props) => {
 
   let rightSidebar = switch props {
   | Ok({module_: {items}}) if Js.Array2.length(items) > 0 =>
-    let rightSidebar = <RightSidebar items />
     <div className="hidden xl:block lg:w-1/5 md:h-auto md:relative overflow-y-visible bg-white">
       <aside
         className="relative top-0 pl-4 w-full block md:top-16 md:pt-16 md:sticky border-l border-gray-20 overflow-y-auto pb-24 h-[calc(100vh-4.5rem)]">
         <div className="hl-overline block text-gray-80 mt-16 mb-2">
           {"Types and values"->React.string}
         </div>
-        <ul> {rightSidebar} </ul>
+        <ul>
+          <RightSidebar items />
+        </ul>
       </aside>
     </div>
   | _ => React.null

--- a/src/ApiDocs.res
+++ b/src/ApiDocs.res
@@ -44,49 +44,46 @@ type item =
 module RightSidebar = {
   @react.component
   let make = (~items: array<item>) => {
-    switch items->Js.Array2.length === 0 {
-    | true => React.null
-    | false =>
-      let valuesAndTypes = items->Js.Array2.map(item => {
-        switch item {
-        | Value({name, deprecated}) as kind | Type({name, deprecated}) as kind =>
-          let (icon, textColor, bgColor, href) = switch kind {
-          | Type(_) => ("t", "text-fire-30", "bg-fire-5", `#type-${name}`)
-          | Value(_) => ("v", "text-sky-30", "bg-sky-5", `#value-${name}`)
-          }
-          let deprecatedIcon = switch deprecated->Js.Null.toOption {
-          | Some(_) =>
-            <div
-              className={`bg-orange-100 min-w-[20px] min-h-[20px] w-5 h-5 mr-3 flex justify-center items-center rounded-xl ml-auto`}>
-              <span className={"text-[10px] text-orange-400"}> {"D"->React.string} </span>
-            </div>->Some
-          | None => None
-          }
-          let title = `${Belt.Option.isSome(deprecatedIcon) ? "Deprecated " : ""}` ++ name
-          let result =
-            <li className="my-3">
-              <a
-                title
-                className="flex items-center w-full font-normal text-14 text-gray-40 leading-tight hover:text-gray-80"
-                href>
-                <div
-                  className={`${bgColor} min-w-[20px] min-h-[20px] w-5 h-5 mr-3 flex justify-center items-center rounded-xl`}>
-                  <span className={"text-[10px] font-normal " ++ textColor}>
-                    {icon->React.string}
-                  </span>
-                </div>
-                <span className={"truncate"}> {React.string(name)} </span>
-                {switch deprecatedIcon {
-                | Some(icon) => icon
-                | None => React.null
-                }}
-              </a>
-            </li>
-          result
+    items
+    ->Js.Array2.map(item => {
+      switch item {
+      | Value({name, deprecated}) as kind | Type({name, deprecated}) as kind =>
+        let (icon, textColor, bgColor, href) = switch kind {
+        | Type(_) => ("t", "text-fire-30", "bg-fire-5", `#type-${name}`)
+        | Value(_) => ("v", "text-sky-30", "bg-sky-5", `#value-${name}`)
         }
-      })
-      valuesAndTypes->React.array
-    }
+        let deprecatedIcon = switch deprecated->Js.Null.toOption {
+        | Some(_) =>
+          <div
+            className={`bg-orange-100 min-w-[20px] min-h-[20px] w-5 h-5 mr-3 flex justify-center items-center rounded-xl ml-auto`}>
+            <span className={"text-[10px] text-orange-400"}> {"D"->React.string} </span>
+          </div>->Some
+        | None => None
+        }
+        let title = `${Belt.Option.isSome(deprecatedIcon) ? "Deprecated " : ""}` ++ name
+        let result =
+          <li className="my-3">
+            <a
+              title
+              className="flex items-center w-full font-normal text-14 text-gray-40 leading-tight hover:text-gray-80"
+              href>
+              <div
+                className={`${bgColor} min-w-[20px] min-h-[20px] w-5 h-5 mr-3 flex justify-center items-center rounded-xl`}>
+                <span className={"text-[10px] font-normal " ++ textColor}>
+                  {icon->React.string}
+                </span>
+              </div>
+              <span className={"truncate"}> {React.string(name)} </span>
+              {switch deprecatedIcon {
+              | Some(icon) => icon
+              | None => React.null
+              }}
+            </a>
+          </li>
+        result
+      }
+    })
+    ->React.array
   }
 }
 


### PR DESCRIPTION
Add a submenu with a link to the value/type in each module:

![image](https://github.com/rescript-association/rescript-lang.org/assets/16160544/4fee95c3-01e1-4ea5-8e41-642e97668bf9)

I didn't really like how it turned out, so any suggestions are welcome.