### PR TITLE
Fix typo

### DIFF
--- a/_blogposts/archive/2020-07-01-bucklescript-8-1-new-syntax.mdx
+++ b/_blogposts/archive/2020-07-01-bucklescript-8-1-new-syntax.mdx
@@ -16,7 +16,7 @@ The release of BuckleScript 8.1 contains a new important addition: we've rewritt
 
 The rewrite was done by a community member of ours, [Maxim](https://twitter.com/_binary_search). Maxim was a main contributor to the old Reason repo, and together we've reached the conclusion a while ago that the codebase needed a revamp. After wrestling with it for the longest time, we've settled on a low-key rewrite.
 
-Syntax discussions have always been churny, so we didn't want to prematurity announce something before it's ready for proper critiques. After testing this extensively; we now deem it solid enough for your consumption.
+Syntax discussions have always been churny, so we didn't want to prematurely announce something before it's ready for proper critiques. After testing this extensively; we now deem it solid enough for your consumption.
 
 **Here's what you need to know:**
 - The new syntax comes directly with your BuckleScript >=8.1 installation. You won't have to install anything else. It does not depend on the old `refmt`.

--- a/_blogposts/archive/2020-07-01-bucklescript-8-1-new-syntax.mdx
+++ b/_blogposts/archive/2020-07-01-bucklescript-8-1-new-syntax.mdx
@@ -16,7 +16,7 @@ The release of BuckleScript 8.1 contains a new important addition: we've rewritt
 
 The rewrite was done by a community member of ours, [Maxim](https://twitter.com/_binary_search). Maxim was a main contributor to the old Reason repo, and together we've reached the conclusion a while ago that the codebase needed a revamp. After wrestling with it for the longest time, we've settled on a low-key rewrite.
 
-Syntax discussions have always been churny, so we didn't want to prematurely announce something before it's ready for proper critiques. After testing this extensively; we now deem it solid enough for your consumption.
+Syntax discussions have always been churny, so we didn't want to prematurely announce something before it's ready for proper critiques. After testing this extensively, we now deem it solid enough for your consumption.
 
 **Here's what you need to know:**
 - The new syntax comes directly with your BuckleScript >=8.1 installation. You won't have to install anything else. It does not depend on the old `refmt`.


### PR DESCRIPTION
“prematurity” → “prematurely”