### PR TITLE
Remove main warn banner

### DIFF
--- a/src/layouts/ManualDocsLayout.res
+++ b/src/layouts/ManualDocsLayout.res
@@ -49,38 +49,6 @@ module Latest = {
     let title = "Language Manual"
     let version = "latest"
 
-    // TODO: Remove this once the work on the v11 milestone is completed.
-    // https://github.com/rescript-association/rescript-lang.org/milestone/6
-    let warnBanner = {
-      open Markdown
-
-      let v10Url =
-        "/" ++
-        (Js.Array2.joinWith(url.base, "/") ++
-        ("/v10.0.0/" ++ Js.Array2.joinWith(url.pagepath, "/")))
-
-      let label = switch Js.Array2.find(Constants.allManualVersions, ((v, _)) => {
-        v === version
-      }) {
-      | Some((_, label)) => label
-      | None => version
-      }
-
-      <div className="mb-10">
-        <Warn>
-          <P>
-            {React.string(
-              "You are currently looking at the " ++
-              (label ++
-              " docs, which are still a work in progress. If you miss anything, you may find it in the older v10.0 docs "),
-            )}
-            <A href=v10Url> {React.string("here")} </A>
-            {React.string(".")}
-          </P>
-        </Warn>
-      </div>
-    }
-
     <LatestLayout
       theme=#Reason
       components
@@ -90,7 +58,6 @@ module Latest = {
       availableVersions=Constants.allManualVersions
       ?frontmatter
       breadcrumbs>
-      warnBanner
       children
     </LatestLayout>
   }


### PR DESCRIPTION
This only removes the main banner, the one in the React docs is still there as it's not done yet.