### PR TITLE
add anchor id as parameter on heading element

### DIFF
--- a/src/components/Markdown.res
+++ b/src/components/Markdown.res
@@ -136,7 +136,7 @@ module H2 = {
   @react.component
   let make = (~id, ~children) => <>
     // Here we know that children is always a string (## headline)
-    <h2 className="group mt-16 mb-3 hl-3">
+    <h2 id className="group mt-16 mb-3 hl-3">
       children
       <span className="ml-2">
         <Anchor id />
@@ -148,7 +148,7 @@ module H2 = {
 module H3 = {
   @react.component
   let make = (~id, ~children) =>
-    <h3 className="group mt-8 mb-4 hl-4">
+    <h3 id className="group mt-8 mb-4 hl-4">
       children
       <span className="ml-2">
         <Anchor id />
@@ -159,7 +159,7 @@ module H3 = {
 module H4 = {
   @react.component
   let make = (~id, ~children) =>
-    <h4 className="group mt-8 hl-5">
+    <h4 id className="group mt-8 hl-5">
       children
       <span className="ml-2">
         <Anchor id />
@@ -171,6 +171,7 @@ module H5 = {
   @react.component
   let make = (~id, ~children) =>
     <h5
+      id
       className="group mt-12 mb-3 text-12 leading-2 font-sans font-semibold uppercase tracking-wide text-gray-80">
       children
       <span className="ml-2">


### PR DESCRIPTION
I'm testing the Algolia extractor, and the results are not correct. The generated links do not have an anchor, so the user does not go to the exact location.

Example:
![image](https://github.com/rescript-association/rescript-lang.org/assets/16160544/cecd1358-c6cb-42d8-b18f-67159ff96c54)
