### PR TITLE
Fix typo

### DIFF
--- a/_blogposts/archive/2020-07-06-a-note-on-bucklescripts-future-commitments.mdx
+++ b/_blogposts/archive/2020-07-06-a-note-on-bucklescripts-future-commitments.mdx
@@ -16,7 +16,7 @@ description: |
 
 Our [new ReScript syntax announcement](/blog/bucklescript-8-1-new-syntax) generated lots of good feedback, but also raised some concerns from community members whose use-cases still align with our goal, but sometimes extend outside of it, and who are worried about further commitments to the ecosystem in the face of new unknowns.
 
-This post is dedicated to answer some commons questions regarding trust, breakages, and future investment.
+This post is dedicated to answer some common questions regarding trust, breakages, and future investment.
 
 ## Q & A
 


### PR DESCRIPTION
“Commons questions” → “Common questions”