### PR TITLE
Update object.mdx

### DIFF
--- a/pages/docs/manual/latest/object.mdx
+++ b/pages/docs/manual/latest/object.mdx
@@ -172,7 +172,7 @@ Since objects don't require type declarations, and since ReScript infers all the
 @val external document: 'a = "document"
 
 // call a method
-document["addEventListener"](. "mouseup", _event => {
+document["addEventListener"]("mouseup", _event => {
   Console.log("clicked!")
 })
 


### PR DESCRIPTION
No longer need the `(.` to uncurry in the tips and tricks section example.