### PR TITLE
Remove some more examples that use the old uncurry code

### DIFF
--- a/pages/docs/manual/latest/converting-from-js.mdx
+++ b/pages/docs/manual/latest/converting-from-js.mdx
@@ -174,7 +174,7 @@ let queryResult = (usePayload, payload) => {
   if usePayload {
     payload["student"]
   } else {
-    school["getStudentById"](. defaultId)
+    school["getStudentById"](defaultId)
   }
 }
 ```
@@ -196,7 +196,7 @@ let queryResult = (usePayload, payload) => {
   if usePayload {
     payload["student"]
   } else {
-    school["getStudentById"](. defaultId)
+    school["getStudentById"](defaultId)
   }
 }
 ```

--- a/pages/docs/manual/latest/external.mdx
+++ b/pages/docs/manual/latest/external.mdx
@@ -50,7 +50,7 @@ Once declared, you can use an `external` as a normal value, just like a let bind
 @val external document: 'a = "document"
 
 // call a method
-document["addEventListener"](."mouseup", _event => {
+document["addEventListener"]("mouseup", _event => {
   Console.log("clicked!")
 })
 


### PR DESCRIPTION
Found some more examples where it used the old `(.` to uncurry things. No longer need this in Rescript v11.