### PR TITLE
Update faq.mdx - async/await has arrived on ReScript 10.1

### DIFF
--- a/pages/docs/manual/latest/faq.mdx
+++ b/pages/docs/manual/latest/faq.mdx
@@ -49,7 +49,7 @@ Currently, we're actively working on the editor support.
 
 **When will we get the `async/await` keywords?**
 
-See our answer on the [Async & Promise](promise) page's intro.
+async/await has arrived in ReScript 10.1!
 
 **Why create a new syntax?**
 


### PR DESCRIPTION
it previously said "See our answer on the [Async & Promise](https://github.com/rescript-association/rescript-lang.org/blob/master/pages/docs/manual/latest/promise) page's intro."