### PR TITLE
separate path for archived posts

### DIFF
--- a/pages/blog/archived.js
+++ b/pages/blog/archived.js
@@ -1,6 +1,6 @@
 import BlogRes from "src/Blog.mjs";
 
-export { getStaticProps_All as getStaticProps } from "src/Blog.mjs";
+export { getStaticProps_Archived as getStaticProps } from "src/Blog.mjs";
 
 export default function Blog(props) {
   return <BlogRes {...props} />

--- a/src/Blog.resi
+++ b/src/Blog.resi
@@ -3,6 +3,9 @@ let defaultPreviewImg: string
 type params
 type props
 
+type category = All | Archived
+
 let default: props => React.element
 
-let getStaticProps: Next.GetStaticProps.t<props, params>
+let getStaticProps_All: Next.GetStaticProps.t<props, params>
+let getStaticProps_Archived: Next.GetStaticProps.t<props, params>

--- a/src/common/BlogApi.resi
+++ b/src/common/BlogApi.resi
@@ -5,6 +5,8 @@ type post = {
 }
 
 let getAllPosts: unit => array<post>
+let getLivePosts: unit => array<post>
+let getArchivedPosts: unit => array<post>
 let blogPathToSlug: string => string
 
 module RssFeed: {


### PR DESCRIPTION
The previous approach (tabs) doesn't preserve URL path for archived posts and therefore doesn't provide basic web browsing experiences such as history-back.

While improving this, it also removes various duplications used to filter posts.

Also, this makes the blog page faster because less initial data is loaded for entry.