### PR TITLE
improve Package search sorting

### DIFF
--- a/src/Packages.res
+++ b/src/Packages.res
@@ -25,7 +25,6 @@ type npmPackage = {
   npmHref: string,
   searchScore: float,
   maintenanceScore: float,
-  score: {"final": float, "detail": {"quality": float, "popularity": float, "maintenance": float}},
 }
 
 // These are packages that we do not want to filter out when loading searching from NPM.
@@ -571,7 +570,6 @@ let parsePkgs = data =>
       npmHref: pkg["links"]["npm"],
       searchScore: item["searchScore"],
       maintenanceScore: item["score"]["detail"]["maintenance"],
-      score: item["score"],
     }
   })
 

--- a/src/Packages.res
+++ b/src/Packages.res
@@ -415,7 +415,7 @@ let default = (props: props) => {
     let isResourceIncluded = switch next {
     | Npm(_) => filter.includeNpm
     | Url(_) => filter.includeUrlResource
-    | Outdated(_) => filter.includeOutdated
+    | Outdated(_) => filter.includeOutdated && filter.includeNpm
     }
     if !isResourceIncluded {
       ()

--- a/src/Packages.res
+++ b/src/Packages.res
@@ -143,7 +143,7 @@ module Resource = {
     let filteredOutdated =
       applyNpmSearch(allOutDated, pattern)->Belt.Array.map(m => Outdated(m["item"]))
 
-    Belt.Array.concat(filteredNpm, filteredUrls)->Belt.Array.concat(filteredOutdated)
+    Belt.Array.concatMany([filteredNpm, filteredUrls, filteredOutdated])
   }
 }
 
@@ -383,7 +383,7 @@ let default = (props: props) => {
     let npms = props["packages"]->Belt.Array.map(pkg => Resource.Npm(pkg))
     let urls = props["urlResources"]->Belt.Array.map(res => Resource.Url(res))
     let outdated = props["unmaintained"]->Belt.Array.map(pkg => Resource.Outdated(pkg))
-    Belt.Array.concat(npms, urls)->Belt.Array.concat(outdated)
+    Belt.Array.concatMany([npms, urls, outdated])
   }
 
   let resources = switch state {

--- a/src/Packages.res
+++ b/src/Packages.res
@@ -572,7 +572,7 @@ let getStaticProps: Next.GetStaticProps.revalidate<props, unit> = async _ctx => 
         true
       } else if pkg.name->Js.String2.includes("reason") {
         false
-      } else if pkg.maintenanceScore < 0.3 {
+      } else if pkg.maintenanceScore < 0.09 {
         false
       } else {
         true

--- a/src/Packages.res
+++ b/src/Packages.res
@@ -28,6 +28,9 @@ type npmPackage = {
   score: {"final": float, "detail": {"quality": float, "popularity": float, "maintenance": float}},
 }
 
+// These are packages that we do not want to filter out when loading searching from NPM.
+let packageAllowList: array<string> = []
+
 module Resource = {
   type t = Npm(npmPackage) | Url(urlResource) | Outdated(npmPackage)
 
@@ -594,7 +597,7 @@ let getStaticProps: Next.GetStaticProps.revalidate<props, unit> = async _ctx => 
     ->Js.Array2.concat(parsePkgs(data2))
     ->Js.Array2.concat(parsePkgs(data3))
     ->Js.Array2.filter(pkg => {
-      if [/* Allow list of names */]->Js.Array2.includes(pkg.name) {
+      if packageAllowList->Js.Array2.includes(pkg.name) {
         true
       } else if pkg.name->Js.String2.includes("reason") {
         false

--- a/src/Packages.resi
+++ b/src/Packages.resi
@@ -13,6 +13,9 @@ type npmPackage = {
   description: string,
   repositoryHref: Js.Null.t<string>,
   npmHref: string,
+  searchScore: float,
+  maintenanceScore: float,
+  score: {"final": float, "detail": {"quality": float, "popularity": float, "maintenance": float}},
 }
 
 type props = {"packages": array<npmPackage>, "urlResources": array<urlResource>}

--- a/src/Packages.resi
+++ b/src/Packages.resi
@@ -18,7 +18,11 @@ type npmPackage = {
   score: {"final": float, "detail": {"quality": float, "popularity": float, "maintenance": float}},
 }
 
-type props = {"packages": array<npmPackage>, "urlResources": array<urlResource>}
+type props = {
+  "packages": array<npmPackage>,
+  "urlResources": array<urlResource>,
+  "unmaintained": array<npmPackage>,
+}
 
 let default: props => React.element
 

--- a/src/Packages.resi
+++ b/src/Packages.resi
@@ -15,7 +15,6 @@ type npmPackage = {
   npmHref: string,
   searchScore: float,
   maintenanceScore: float,
-  score: {"final": float, "detail": {"quality": float, "popularity": float, "maintenance": float}},
 }
 
 type props = {


### PR DESCRIPTION
- increase number of included packages from 250 to 750 (currently 512)
- filter out packages with a low maintenance score (< 0.3) and add in a filter to show "outdated" packages
- add query params to npm registry api call to adjust weights to favor maintenance and quality
- sort by weight in the UI
- filter out packages with "reason" in the title to keep the focus on ReScript specific packages

![image](https://github.com/rescript-association/rescript-lang.org/assets/60623931/80140eff-a820-4bb3-9bde-083b952a34f5)


| Before | After |
| -- | -- |
| ![image](https://github.com/rescript-association/rescript-lang.org/assets/60623931/552c926e-904c-49d6-a2c9-5b5048908588) | ![image](https://github.com/rescript-association/rescript-lang.org/assets/60623931/357b9944-3058-4158-a8a8-22fcc4184189) |
|![image](https://github.com/rescript-association/rescript-lang.org/assets/60623931/16ecd906-5a7c-4e3a-b9b4-d483f3640283) | ![image](https://github.com/rescript-association/rescript-lang.org/assets/60623931/7f6ce189-43ff-4e1c-a51e-063e3f6c2dbd)|

