### PR TITLE
Add missing usage in the example

### DIFF
--- a/pages/docs/manual/latest/bind-to-js-function.mdx
+++ b/pages/docs/manual/latest/bind-to-js-function.mdx
@@ -124,6 +124,9 @@ type sessionResult
 @scope(("checkout", "sessions"))
 external createCheckoutSession: (stripe, createSession) => 
   Promise.t<sessionResult> = "create"
+
+let stripe = make("sk_...")
+let session = stripe->createCheckoutSession({})
 ```
 ```js
 import Stripe from "stripe";


### PR DESCRIPTION
@fhammerschmidt the ReScript part was missing the actual usage in my example.
Sorry about that.