### PR TITLE
Correct comparison operator in Array.every() method

### DIFF
--- a/data/api/latest/core.json
+++ b/data/api/latest/core.json
@@ -9782,7 +9782,7 @@
         "kind": "value",
         "name": "every",
         "docstrings": [
-          "`every(array, predicate)` returns true if `predicate` returns true for all items in `array`.\n\nSee [`Array.every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every) on MDN.\n\n## Examples\n```rescript\nlet array = [1, 2, 3, 4]\n\nConsole.log(array->Array.every(num => num < 4)) // true\nConsole.log(array->Array.every(num => num === 1)) // false\n```"
+          "`every(array, predicate)` returns true if `predicate` returns true for all items in `array`.\n\nSee [`Array.every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every) on MDN.\n\n## Examples\n```rescript\nlet array = [1, 2, 3, 4]\n\nConsole.log(array->Array.every(num => num <= 4)) // true\nConsole.log(array->Array.every(num => num === 1)) // false\n```"
         ],
         "signature": "let every: (array<'a>, 'a => bool) => bool"
       },

--- a/data/api/latest/core.json
+++ b/data/api/latest/core.json
@@ -9782,7 +9782,7 @@
         "kind": "value",
         "name": "every",
         "docstrings": [
-          "`every(array, predicate)` returns true if `predicate` returns true for all items in `array`.\n\nSee [`Array.every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every) on MDN.\n\n## Examples\n```rescript\nlet array = [1, 2, 3, 4]\n\nConsole.log(array->Array.every(num => num > 4)) // true\nConsole.log(array->Array.every(num => num === 1)) // false\n```"
+          "`every(array, predicate)` returns true if `predicate` returns true for all items in `array`.\n\nSee [`Array.every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every) on MDN.\n\n## Examples\n```rescript\nlet array = [1, 2, 3, 4]\n\nConsole.log(array->Array.every(num => num < 4)) // true\nConsole.log(array->Array.every(num => num === 1)) // false\n```"
         ],
         "signature": "let every: (array<'a>, 'a => bool) => bool"
       },


### PR DESCRIPTION
Fix typo in Array.every() comparison operator
Yay, my first contribution 
```rescript
let array = [1, 2, 3, 4]

//before
Console.log(array->Array.every(num => num > 4)) // true

//after
Console.log(array->Array.every(num => num <= 4)) // true
```