### PR TITLE
Fix grammar in let-binding.mdx

### DIFF
--- a/pages/docs/manual/latest/let-binding.mdx
+++ b/pages/docs/manual/latest/let-binding.mdx
@@ -181,5 +181,5 @@ Still, `%%private` is useful in the following scenarios:
 
 - **Code generators.** Some code generators want to hide some values but it is sometimes very hard or time consuming for code generators to synthesize the types for public fields.
 
-- **Quick prototyping.** During prototyping, we still want to hide some values, but the interface file is not stable yet, `%%private` provide you such convenience.
+- **Quick prototyping.** During prototyping, we still want to hide some values, but the interface file is not stable yet. `%%private` provides you such convenience.
 

--- a/pages/docs/manual/v10.0.0/let-binding.mdx
+++ b/pages/docs/manual/v10.0.0/let-binding.mdx
@@ -181,5 +181,5 @@ Still, `%%private` is useful in the following scenarios:
 
 - **Code generators.** Some code generators want to hide some values but it is sometimes very hard or time consuming for code generators to synthesize the types for public fields.
 
-- **Quick prototyping.** During prototyping, we still want to hide some values, but the interface file is not stable yet, `%%private` provides you such convenience.
+- **Quick prototyping.** During prototyping, we still want to hide some values, but the interface file is not stable yet. `%%private` provides you such convenience.
 

--- a/pages/docs/manual/v8.0.0/let-binding.mdx
+++ b/pages/docs/manual/v8.0.0/let-binding.mdx
@@ -217,5 +217,5 @@ Still, `%private` is useful in the following scenarios:
 
 - Code generators. Some code generators want to hide some values but it is sometimes very hard or time consuming for code generators to synthesize the types for public fields.
 
-- Quick prototyping. During prototyping, we still want to hide some values, but the interface file is not stable yet, `%private` provide you such convenience.
+- Quick prototyping. During prototyping, we still want to hide some values, but the interface file is not stable yet. `%private` provides you such convenience.
 

--- a/pages/docs/manual/v9.0.0/let-binding.mdx
+++ b/pages/docs/manual/v9.0.0/let-binding.mdx
@@ -181,5 +181,5 @@ Still, `%private` is useful in the following scenarios:
 
 - Code generators. Some code generators want to hide some values but it is sometimes very hard or time consuming for code generators to synthesize the types for public fields.
 
-- Quick prototyping. During prototyping, we still want to hide some values, but the interface file is not stable yet, `%private` provide you such convenience.
+- Quick prototyping. During prototyping, we still want to hide some values, but the interface file is not stable yet. `%private` provides you such convenience.
 


### PR DESCRIPTION
Change comma to period and add 's' to 'provide' in the private let bindings section of let-binding documentation.