### PR TITLE
fix typo in `extensions-of-props.mdx`

### DIFF
--- a/pages/docs/react/latest/extensions-of-props.mdx
+++ b/pages/docs/react/latest/extensions-of-props.mdx
@@ -131,7 +131,7 @@ module Screen: {
 />
 ```
 
-This example cann't pass the type checker, because the props types of both components are nominally different. You can make the both components having the same props type by passing `screenProps` type as argument to `@react.component`.
+This example can't pass the type checker, because the props types of both components are nominally different. You can make the both components having the same props type by passing `screenProps` type as argument to `@react.component`.
 
 ```res
 module A = {


### PR DESCRIPTION
Change `cann't` to `can't` in `extensions-of-props.mdx`