### PR TITLE
Add link to Promise.catch API docs

### DIFF
--- a/pages/docs/manual/latest/promise.mdx
+++ b/pages/docs/manual/latest/promise.mdx
@@ -77,6 +77,10 @@ let logAsyncMessage = async () => {
 
 Needless to say, the async / await version offers better ergonomics and less opportunities to run into type issues.
 
+### Handling Rejected Promises
+
+You can handle a rejected promise using the [`Promise.catch()`](./api/core/promise#value-catch) method, which allows you to catch and manage errors effectively.
+
 ### Run multiple promises in parallel
 
 In case you want to launch multiple promises in parallel, use `Promise.all`:


### PR DESCRIPTION
Fixes https://github.com/rescript-association/rescript-lang.org/issues/904
The API docs are sufficient, just wanted to add additional link there so people can find it.

//cc @fhammerschmidt  