### PR TITLE
Correctly sort experimental compiler versions available in playground

### DIFF
--- a/src/Playground.res
+++ b/src/Playground.res
@@ -910,28 +910,30 @@ module Settings = {
               {switch experimentalVersions {
               | [] => React.null
               | experimentalVersions =>
-                let versionByOrder = experimentalVersions->Belt.SortArray.stableSortBy((a, b) => {
-                  let cmp = ({Semver.major: major, minor, patch, preRelease}) => {
-                    let preRelease = switch preRelease {
-                    | Some(preRelease) =>
-                      switch preRelease {
-                      | Dev(id) => 0 + id
-                      | Alpha(id) => 10 + id
-                      | Beta(id) => 20 + id
-                      | Rc(id) => 30 + id
+                let versionByOrder = experimentalVersions->Array.toSorted((b, a) => {
+                  if a.major != b.major {
+                    a.major - b.major
+                  } else if a.minor != b.minor {
+                    a.minor - b.minor
+                  } else if a.patch != b.patch {
+                    a.patch - b.patch
+                  } else {
+                    switch (a.preRelease, b.preRelease)->Option.all2 {
+                    | Some((prereleaseA, prereleaseB)) =>
+                      switch (prereleaseA, prereleaseB) {
+                      | (Rc(rcA), Rc(rcB)) => rcA - rcB
+                      | (Rc(rcA), _) => rcA
+                      | (Beta(betaA), Beta(betaB)) => betaA - betaB
+                      | (Beta(betaA), _) => betaA
+                      | (Alpha(alphaA), Alpha(alphaB)) => alphaA - alphaB
+                      | (Alpha(alphaA), _) => alphaA
+                      | (Dev(devA), Dev(devB)) => devA - devB
+                      | (Dev(devA), _) => devA
                       }
+
                     | None => 0
                     }
-                    let number =
-                      [major, minor, patch]
-                      ->Array.map(v => v->Int.toString)
-                      ->Array.join("")
-                      ->Int.fromString
-                      ->Option.getOr(0)
-
-                    number + preRelease
-                  }
-                  cmp(b) - cmp(a)
+                  }->Float.fromInt
                 })
                 <>
                   <VersionSelect.SectionHeader value=Constants.dropdownLabelNext />


### PR DESCRIPTION
The existing sort logic assumed that there are only up to 10 dev/alpha/beta/rc releases per version, but v12 had 15 alphas.

| Before | After |
| ------ | ----- |
| <img width="240" height="408" alt="image" src="https://github.com/user-attachments/assets/fb04af5f-605f-40b5-bafa-4e53d9a30270" /> | <img width="240" height="408" alt="image" src="https://github.com/user-attachments/assets/28a68fdc-2767-47f1-b72f-43465ea74ea2" /> |
