### PR TITLE
Convert a repository url from SSH to HTTPS.

### DIFF
--- a/src/Packages.res
+++ b/src/Packages.res
@@ -503,15 +503,10 @@ let parsePkgs = data => {
 
         // Convert a repository url from SSH to HTTPS.
         let repositoryHref = switch repositoryHref {
-          | href if String.startsWith(href, "git+ssh") => {
-            String.replace(href, "git+ssh:", "https:")          }
-          | href if String.startsWith(href, "git+") => {
-            String.replace(href, "git+", "")
-          }
-          | href if String.startsWith(href, "git:") => {
-            String.replace(href, "git:", "https:")
-          }
-          | href => href
+        | href if String.startsWith(href, "git+ssh") => String.replace(href, "git+ssh:", "https:")
+        | href if String.startsWith(href, "git+") => String.replace(href, "git+", "")
+        | href if String.startsWith(href, "git:") => String.replace(href, "git:", "https:")
+        | href => href
         }
 
         Some({


### PR DESCRIPTION
This pull request fixes broken repository links on the Packages page.

Currently, links fail when a package's repository is defined with a Git-specific URL scheme (e.g., git+ssh:, git:, git+). This PR introduces logic to convert these schemes into a standard HTTPS format.