### PR TITLE
update links back to current docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "test": "node scripts/test-examples.mjs && node scripts/test-hrefs.mjs",
     "reanalyze": "reanalyze -all-cmt .",
     "update-index": "node scripts/extract-tocs.mjs && node scripts/extract-syntax.mjs",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "sync-bundles": "echo 'Skipping bundle sync for older docs...'"
   },
   "devDependencies": {
     "@mdx-js/react": "^2.3.0",

--- a/src/SyntaxLookup.res
+++ b/src/SyntaxLookup.res
@@ -352,8 +352,14 @@ let default = (props: props) => {
           <div className="mb-8 text-gray-60-tr text-14">
             {React.string("Enter some language construct you want to know more about.")}
           </div>
+          <p className="text-11 text-gray-70 mt-14 md:mt-4">
+            {React.string("You are viewing docs for an older version of ReScript.")}
+          </p>
+          <a href="https://rescript-lang.org/syntax-lookup" className="text-11 text-fire underline">
+            {React.string("Go to the latest version.")}
+          </a>
         </div>
-        <div className="w-full max-w-[34rem]">
+        <div className="w-full max-w-[34rem] mt-8">
           <SearchBox
             placeholder="Enter keywords or syntax..."
             completionValues={Array.map(completionItems, item => item.name)}

--- a/src/common/Util.res
+++ b/src/common/Util.res
@@ -84,7 +84,10 @@ let removeVersionFromPathname = (pathname: string) =>
   pathname
   ->Stdlib.String.split("/")
   ->Array.filter(s => {
-    let isVersion = s->Stdlib.String.includes("v") && s->Stdlib.String.includes(".")
+    let isVersion =
+      (s->Stdlib.String.includes("v") && s->Stdlib.String.includes(".")) ||
+      s == "latest" ||
+      s == "next"
     !isVersion
   })
   ->Array.join("/")

--- a/src/layouts/SidebarLayout.res
+++ b/src/layouts/SidebarLayout.res
@@ -133,8 +133,6 @@ module Sidebar = {
         None
       }
 
-    let {pathname} = Next.Router.useRouter()
-
     <>
       <div
         id="sidebar"
@@ -152,16 +150,7 @@ module Sidebar = {
             className="md:hidden h-16 flex pt-2 right-4 absolute">
             <Icon.Close />
           </button>
-          <div className="mb-4">
-            <p className="text-11">
-              {React.string("You are viewing an older version of the documentation.")}
-            </p>
-            <a
-              className="text-11 text-fire-30 border-b border-fire"
-              href={`https://rescript-lang.org${pathname->Util.removeVersionFromPathname}`}>
-              {React.string("Go to the latest version.")}
-            </a>
-          </div>
+
           <div className="flex justify-between">
             <div className="w-3/4 md:w-full"> toplevelNav </div>
           </div>
@@ -252,6 +241,8 @@ let make = (
     setSidebarOpen(prev => !prev)
   }
 
+  let pathname = router.pathname
+
   React.useEffect(() => {
     open Next.Router.Events
     let {Next.Router.events: events} = router
@@ -338,12 +329,13 @@ let make = (
                   </div>
                 </div>
                 <p className="text-11 text-gray-70 mt-14 md:mt-4">
-                  <a href="">
-                    {React.string("You are viewing docs for an older version of Rescript.")}
-                    <br />
-                    {React.string("Go to latest version.")}
-                  </a>
+                  {React.string("You are viewing docs for an older version of ReScript.")}
                 </p>
+                <a
+                  href={`https://rescript-lang.org${pathname->Util.removeVersionFromPathname}`}
+                  className="text-11 text-fire underline">
+                  {React.string("Go to the latest version.")}
+                </a>
                 <div className={hasBreadcrumbs ? "mt-10" : "mt-6 md:-mt-4"}>
                   <MdxProvider components> children </MdxProvider>
                 </div>


### PR DESCRIPTION
Update links to current version.

Added one to the syntax page.
<img width="1199" height="493" alt="image" src="https://github.com/user-attachments/assets/8d2d6c2c-e7d1-44fb-92a7-f2ff924c7e6c" />

Removed the one in the sidebar and fixed the one above the docs.
<img width="1190" height="450" alt="image" src="https://github.com/user-attachments/assets/3e8dda44-42a8-4a63-a018-c1483eb0fd49" />
