### PR TITLE
update playground highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@replit/codemirror-vim": "^6.3.0",
     "@rescript/react": "^0.14.0",
     "@rescript/webapi": "0.1.0-experimental-29db5f4",
-    "@tsnobip/rescript-lezer": "^0.6.0",
+    "@tsnobip/rescript-lezer": "^0.7.0",
     "docson": "^2.1.0",
     "fuse.js": "^6.4.3",
     "glob": "^7.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2342,14 +2342,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsnobip/rescript-lezer@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@tsnobip/rescript-lezer@npm:0.6.0"
+"@tsnobip/rescript-lezer@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@tsnobip/rescript-lezer@npm:0.7.0"
   dependencies:
     "@lezer/common": "npm:^1.2.3"
     "@lezer/highlight": "npm:^1.2.1"
     "@lezer/lr": "npm:^1.4.2"
-  checksum: 10c0/9e10dd6906bd7d18b3aa3004bdb78091861dae6fdd72f489557a9d2f4ed0a0fee63b80df9fe783ed0d1210a100799502e879893f2c58b87ceb3e4ba8e7060f45
+  checksum: 10c0/7f8b1e3c04bf0a2aa9306d3d4213a8e3b7b79901a85aa942b9658ce971ce95f71582d51b7ade40f7141df09b37beb428133819b6eaf559108d73e4138b583f45
   languageName: node
   linkType: hard
 
@@ -8122,7 +8122,7 @@ __metadata:
     "@rescript/react": "npm:^0.14.0"
     "@rescript/webapi": "npm:0.1.0-experimental-29db5f4"
     "@tailwindcss/vite": "npm:^4.1.13"
-    "@tsnobip/rescript-lezer": "npm:^0.6.0"
+    "@tsnobip/rescript-lezer": "npm:^0.7.0"
     "@types/react": "npm:^19.2.2"
     "@vitejs/plugin-react": "npm:^4.7.0"
     chokidar: "npm:^4.0.3"


### PR DESCRIPTION
Module types and record optional field punning was not well supported, this is now fixed with rescript-lezer v0.7.0, eg:
```res
module Foo: {
  type t
  let make: (~bar: option<int>=?, ~baz: option<int>=?) => t
} = {
  type t = {
    bar?: option<int>,
    baz?: option<int>,
  }
  let make = (~bar: option<option<int>>=?, ~baz=?) => {?bar, ?baz}
}
```
compare highlighting of this code with [this PR](https://improve-highlighting.rescript-lang.pages.dev/try?version=v12.0.0&module=esmodule&code=LYewJgrgNgpgBAMRCAXHA3gKDnALgTwAd5ds5Zc5gBDAaxjQAoA-AI2oCc0RDcBLEADsAPH0G4AfAF4A-ABo4bagC9uvASLGTZASjhSJeTAF99GMgWJ4zWHDnYcZa-kNHiJcsvZVO4PF5runjjGZBRUdPBScCwOzhrC-glaEtLyiuzKuvqG6DIOCvkqocZAA) vs [master](https://rescript-lang.org/try/?version=v12.0.0-rc.3&module=esmodule&code=LYewJgrgNgpgBAMRCAXHA3gKDnALgTwAd5ds5Zc5gBDAaxjQAoA-AI2oCc0RDcBLEADsAPH0G4AfAF4A-ABo4bagC9uvASLGTZASjhSJeTAF99GMgWJ4zWHDnYcZa-kNHiJcsvZVO4PF5runjjGZBRUdPBScCwOzhrC-glaEtLyiuzKuvqG6DIOCvkqocZAA)