### PR TITLE
fix: remove truncate class from sidebar titles

### DIFF
--- a/src/layouts/SidebarLayout.res
+++ b/src/layouts/SidebarLayout.res
@@ -91,7 +91,7 @@ module Sidebar = {
             <Link.String
               to=m.href
               prefetch={#intent}
-              className={"truncate block py-1 md:h-auto tracking-tight text-gray-60 rounded-sm hover:bg-gray-20 hover:-ml-2 hover:py-1 hover:pl-2 " ++
+              className={"block py-1 md:h-auto tracking-tight text-gray-60 rounded-sm hover:bg-gray-20 hover:-ml-2 hover:py-1 hover:pl-2 " ++
               active}
             >
               {React.string(m.name)}


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-lang.org/issues/81 by removing the `truncate` class.

### Before
<img width="532" height="380" alt="image" src="https://github.com/user-attachments/assets/ea823eb2-9d92-4710-bb7b-61d156949976" />

### After
<img width="520" height="490" alt="image" src="https://github.com/user-attachments/assets/cad310c5-b49c-42a7-91e5-fd0db59eb573" />
