### PR TITLE
Fix Accessibility Violations - Add Accessible Names to Interactive El…

### DIFF
--- a/src/components/Navigation.res
+++ b/src/components/Navigation.res
@@ -177,16 +177,16 @@ let make = (~fixed=true, ~isOverlayOpen: bool, ~setOverlayOpen: (bool => bool) =
             <div className="md:flex flex items-center text-gray-60">
               <Search />
               <div className="hidden md:flex items-center ml-5">
-                <a href=Constants.githubHref rel="noopener noreferrer" className={"mr-5 " ++ link} aria-label="GitHub">
+                <a href=Constants.githubHref rel="noopener noreferrer" className={"mr-5 " ++ link} ariaLabel="GitHub">
                   <Icon.GitHub className="w-6 h-6 opacity-50 hover:opacity-100" />
                 </a>
-                <a href=Constants.xHref rel="noopener noreferrer" className={"mr-5 " ++ link} aria-label="X (formerly Twitter)">
+                <a href=Constants.xHref rel="noopener noreferrer" className={"mr-5 " ++ link} ariaLabel="X (formerly Twitter)">
                   <Icon.X className="w-6 h-6 opacity-50 hover:opacity-100" />
                 </a>
-                <a href=Constants.blueSkyHref rel="noopener noreferrer" className={"mr-5 " ++ link} aria-label="Bluesky">
+                <a href=Constants.blueSkyHref rel="noopener noreferrer" className={"mr-5 " ++ link} ariaLabel="Bluesky">
                   <Icon.Bluesky className="w-6 h-6 opacity-50 hover:opacity-100" />
                 </a>
-                <a href=Constants.discourseHref rel="noopener noreferrer" className=link aria-label="Forum">
+                <a href=Constants.discourseHref rel="noopener noreferrer" className=link ariaLabel="Forum">
                   <Icon.Discourse className="w-6 h-6 opacity-50 hover:opacity-100" />
                 </a>
               </div>

--- a/src/components/Search.res
+++ b/src/components/Search.res
@@ -143,7 +143,7 @@ let make = () => {
   }, [setState])
 
   <>
-    <button onClick type_="button" className="text-gray-60 hover:text-fire-50 p-2" aria-label="Search">
+    <button onClick type_="button" className="text-gray-60 hover:text-fire-50 p-2" ariaLabel="Search">
       <Icon.MagnifierGlass className="fill-current" />
     </button>
     {switch state {


### PR DESCRIPTION
## Summary
This PR fixes 6 critical accessibility violations on [website homepage](https://rescript-lang.org/) identified by the IBM Equal Access Accessibility Checker, where interactive elements (links and buttons) containing only images/icons lacked accessible names, making them unusable for screen reader users.

## Problems Identified
<img width="2560" height="886" alt="image" src="https://github.com/user-attachments/assets/09f9f901-2968-4db0-b789-e94db20569c0" />

### Issue 1: Logo Images Missing Alt Text (1 violations, blue box)

Violation: Hyperlink has no link text, label or image with a text alternative
Elements: Two <img> tags within the homepage link (responsive logo variants)
Impact: Screen reader users cannot identify that these images are clickable links to the homepage or understand their purpose

### Issue 2: Search Button Icon Missing Label (1 violation, red box)

Violation: SVG element has no accessible name
Element: Magnifier glass SVG icon within search button
Impact: Screen reader users cannot identify the button's purpose

### Issue 3: Social Media Icon Links Missing Labels (4 violations, yellow box)

Violation: Hyperlink has no link text, label or image with a text alternative
Elements: GitHub, X (Twitter), Bluesky, and Discourse links containing only SVG icons
Impact: Screen reader users hear only "link" without any context about the destination

## Solutions

### Fix 1: Add Alt Text to Logo Images
Added descriptive `alt="ReScript Home"` attributes to both logo image variants, clearly indicating they link to the homepage.

### Fix 2: Make Search Button Accessible
Added `aria-label="Search"` to the search button

### Fix 3: Add Aria-Labels to Social Media Links
Added descriptive `aria-label` attributes to each social media link:

## Testing

All icon elements have been added description text: 
**Screenshot of Fix After**
<img width="1931" height="917" alt="image" src="https://github.com/user-attachments/assets/3128f70d-ba36-46de-9e8f-22f3cf1745e6" />


## Additional Info
The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications.