### PR TITLE
Fix Accessibility Violations - Add Accessible Labels to Copy Buttons

### DIFF
--- a/src/layouts/LandingPageLayout.res
+++ b/src/layouts/LandingPageLayout.res
@@ -220,6 +220,7 @@ module QuickInstall = {
         disabled={state === Copied}
         className="relative h-10 w-10 flex justify-center items-center "
         onClick
+        ariaLabel={"Copy " ++ code ++ " command"}
       >
         <Icon.Copy className="w-6 h-6 mt-px text-gray-40 hover:cursor-pointer hover:text-gray-80" />
       </button>


### PR DESCRIPTION
## Summary
This PR fixes accessibility violations in the Quick Install section where copy-to-clipboard buttons lack accessible labels, making them unusable for screen reader users.
<img width="2560" height="922" alt="image" src="https://github.com/user-attachments/assets/3127bc56-ca7a-4363-aa41-e5d08aa58e38" />

**Why is this important?**
Associating a meaningful label with every UI control allows the browser and assistive technology to expose and announce the control to a user. Associating a visible label also provides a larger clickable area.

## Problems Identified
The IBM Equal Access Accessibility Checker identified critical violations:
### Issue 1: npm install Command Copy Button

- Violation: Form control element `<button>` has no associated label
- Element: Copy button for `npm install rescript` command
- Impact: Screen reader users cannot identify the button's purpose or what content will be copied

### Issue 2: npx create Command Copy Button

- Violation: Form control element `<button>` has no associated label
- Element: Copy button for `npx create-rescript-app` command
- Impact: Screen reader users cannot identify the button's purpose or what content will be copied


## Solution
Added a descriptive ariaLabel prop to the copy button that dynamically includes the command being copied:
```rescript
ariaLabel={"Copy " ++ code ++ " command"}
```

## Testing

- Validated with IBM Equal Access Accessibility Checker - both violations resolved
- Tested with screen readers (NVDA/JAWS) to confirm proper label announcement
- Verified labels are correctly generated for both commands

**Fix Before:**
<img width="1169" height="389" alt="image" src="https://github.com/user-attachments/assets/4cb4add7-5f8b-420f-8b12-8bb02f306878" />

**Fix After:**
<img width="1157" height="316" alt="image" src="https://github.com/user-attachments/assets/e96b219d-3909-43a7-a70f-508d2cb465e0" />
