### PR TITLE
Fix algolia returing a null value on lvl1 on certain pages

### DIFF
--- a/src/bindings/DocSearch.res
+++ b/src/bindings/DocSearch.res
@@ -10,8 +10,8 @@ type contentType =
   | @as("lvl6") Lvl6
 
 type hierarchy = {
-  lvl0: string,
-  lvl1: string,
+  lvl0: Nullable.t<string>,
+  lvl1: Nullable.t<string>,
   lvl2: Nullable.t<string>,
   lvl3: Nullable.t<string>,
   lvl4: Nullable.t<string>,


### PR DESCRIPTION
Fixes #1161
While working with the project, I discovered that Algolia sends unexpected null values when searching for certain strings. The culprits appear to be "publish" and "libraries", which both reference `markdown-pages/docs/manual/libraries.mdx`. When searching for a substring within this page, DocSearch crashes because it attempts to call replace on an lvl1 value that is null.
During my investigation, I noticed that Algolia was sending content that doesn't exist on the same page, maybe some misalignment? So perhaps that's the reason for this bug and my fix may be redundant. However, if Algolia can send null values, it's breaking the specified contract and we shouldn't trust their data implicitly.

Does my fix makes sense? Or there is a better way?