### PR TITLE
Fix guideline link

### DIFF
--- a/app/routes/MdxRoute.res
+++ b/app/routes/MdxRoute.res
@@ -299,7 +299,8 @@ let default = () => {
       </>
     } else if (
       (pathname :> string)->String.includes("docs/manual") ||
-        (pathname :> string)->String.includes("docs/react")
+      (pathname :> string)->String.includes("docs/react") ||
+      (pathname :> string)->String.includes("docs/guidelines")
     ) {
       <>
         <Meta title=title description={attributes.description->Nullable.getOr("")} />


### PR DESCRIPTION
Fixes #1178

Added `docs/guidelines` to the rendering conditional so the page uses `DocsLayout` instead of falling through to `React.null`

The page has still a strange artifact for the "Back to packages" link, what would be the best fix?

<img width="1231" height="877" alt="Screenshot 2026-01-30 at 14 58 16" src="https://github.com/user-attachments/assets/59276701-7cec-4a52-8a7c-b4422245d18b" />
