### PR TITLE
Fix api doc page not scrollable

### DIFF
--- a/src/ApiDocs.res
+++ b/src/ApiDocs.res
@@ -288,13 +288,19 @@ module DocstringsStylize = {
 
 let make = (props: props) => {
   let (_, setScrollLock) = ScrollLockContext.useScrollLock()
-  let (isSidebarOpen, setSidebarOpen) = React.useState(_ => true)
+  let isMobile = Hooks.useIsMobile()
+  let (isSidebarOpen, setSidebarOpen) = React.useState(_ => false)
 
-  let toggleSidebar = () =>
-    setSidebarOpen(prev => {
-      setScrollLock(_ => !prev)
-      !prev
-    })
+  React.useEffect(() => {
+    setSidebarOpen(_ => !isMobile)
+    None
+  }, [isMobile])
+
+  let toggleSidebar = () => {
+    let nextSidebarOpen = !(isSidebarOpen && isMobile)
+    setSidebarOpen(_ => nextSidebarOpen)
+    setScrollLock(_ => nextSidebarOpen && isMobile)
+  }
 
   let children = {
     open Markdown

--- a/src/common/Hooks.res
+++ b/src/common/Hooks.res
@@ -69,3 +69,21 @@ let useScrollDirection = (~topMargin=80, ~threshold=20) => {
 
   scrollDir
 }
+
+let useIsMobile = (~breakpoint=768) => {
+  let (isMobile, setIsMobile) = React.useState(() => false)
+
+  React.useEffect(() => {
+    let check = () => window.innerWidth < breakpoint
+    setIsMobile(_ => check())
+
+    let onResize = _ => {
+      setIsMobile(_ => check())
+    }
+
+    WebAPI.Window.addEventListener(window, Resize, onResize)
+    Some(() => WebAPI.Window.removeEventListener(window, Resize, onResize))
+  }, [breakpoint])
+
+  isMobile
+}


### PR DESCRIPTION
Fixes part of #1162
This addresses a sidebar state management issue where the scrollbar behavior and sidebar state aren't properly coordinated.

I **think** the intended behavior should be:

- Desktop/tablet: sidebar always open, page scrollbar visible
- Mobile: sidebar toggles open/closed, scrollbar locked when sidebar is open

However, the current implementation has some issues:

1. On page render, `isSidebarOpen` flashes from `true` to `false` even when the sidebar is clearly visible
2. Clicking the sidebar toggle affects both `scrollLock` and `isSidebarOpen` on all screen sizes, even though this behavior should only apply to mobile (I think)
3. The sidebar state issues aren't immediately obvious because CSS media queries independently control sidebar visibility, hiding the underlying state management problems

I've updated the logic so that sidebar state management primarily matters on mobile, with the sidebar defaulting to open on larger screens, but I had to add an hook to check if we are on mobile with an hardcoded breakpoint

This makes the docs more usable, but I'd love feedback on how to improve it! 🙂