### PR TITLE
Fix mutation page sentence about ref

### DIFF
--- a/markdown-pages/docs/manual/mutation.mdx
+++ b/markdown-pages/docs/manual/mutation.mdx
@@ -72,7 +72,7 @@ myValue.contents = 6;
 
 </CodeTab>
 
-Note the `mut` at binding; see [let binding](./let-binding.mdx)!. While a tuple is always
+Note that the previous binding `five` stays `5`, since it got the underlying item on the `ref` box, not the `ref` itself.
 
 **Note**: you might see in the JS output tabs above that `ref` allocates an object. Worry not; local, non-exported `ref`s allocations are optimized away.
 


### PR DESCRIPTION
Fixes #1181

Reverted the content of the documentation to the commit before the incomplete sentence.
