### PR TITLE
fix: scroll lock on link click

### DIFF
--- a/src/common/Hooks.res
+++ b/src/common/Hooks.res
@@ -69,3 +69,23 @@ let useScrollDirection = (~topMargin=80, ~threshold=20) => {
 
   scrollDir
 }
+
+type mediaQueryListEvent = {matches: bool}
+
+let useMediaQuery = (query: string) => {
+  let (matches, setMatches) = React.useState(() => {
+    false
+  })
+
+  React.useEffect(() => {
+    let mediaQueryList = WebAPI.Window.matchMedia(window, query)
+    setMatches(_ => mediaQueryList.matches)
+
+    let listener = (e: mediaQueryListEvent) => setMatches(_ => e.matches)
+
+    WebAPI.MediaQueryList.addEventListener(mediaQueryList, Change, listener)
+    Some(() => WebAPI.MediaQueryList.removeEventListener(mediaQueryList, Change, listener))
+  }, [query])
+
+  matches
+}


### PR DESCRIPTION
This fixes the scroll lock when clicking on sidebar links in the right sidebar.

The problem is, we only want scroll-lock on mobile viewports, because the sidebar (dropdown nav menu) overlays the screen there. On other viewport sizes the sidebar is in a different location and always open.

Because the sidebar component is heavily reused I could not figure out a cleaner solution without media queries.