### PR TITLE
refactor: split out docs/manual routes from shared MdxRoute file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,12 @@ let default: unit => React.element
 - **Lefthook** runs `yarn format` on pre-commit (auto-stages fixed files).
 - Generated `.mjs`/`.jsx` output files from ReScript are git-tracked but excluded from Prettier.
 
+## Pull Requests and Commits
+
+- Use conventional commits format for commit messages (e.g. `feat: add new API docs`, `fix: resolve loader data issue`).
+- Commit bodies should explain what changed with some concise details
+- PR descriptions should provide context for the change, a summary of the changes with descriptions, and reference any related issues.
+
 ## Important Warnings
 
 - Do **not** modify generated `.jsx` / `.mjs` files directly — they are ReScript compiler output.

--- a/app/routes.res
+++ b/app/routes.res
@@ -33,10 +33,20 @@ let blogArticleRoutes =
     route(path, "./routes/BlogArticleRoute.jsx", ~options={id: path})
   )
 
+let docsManualRoutes =
+  MdxFile.scanPaths(~dir="markdown-pages/docs/manual", ~alias="docs/manual")
+  ->Array.filter(path => !String.includes(path, "docs/manual/api"))
+  ->Array.map(path => route(path, "./routes/DocsManualRoute.jsx", ~options={id: path}))
+
 let mdxRoutes = mdxRoutes("./routes/MdxRoute.jsx")->Array.filter(r =>
   !(
     r.path
-    ->Option.map(path => path === "blog" || String.startsWith(path, "blog/"))
+    ->Option.map(path =>
+      path === "blog" ||
+      String.startsWith(path, "blog/") ||
+      ((path === "docs/manual" || String.startsWith(path, "docs/manual/")) &&
+        path !== "docs/manual/api")
+    )
     ->Option.getOr(false)
   )
 )
@@ -56,6 +66,7 @@ let default = [
   ...stdlibRoutes,
   ...beltRoutes,
   ...blogArticleRoutes,
+  ...docsManualRoutes,
   ...mdxRoutes,
   route("*", "./routes/NotFoundRoute.jsx"),
 ]

--- a/app/routes/DocsManualRoute.res
+++ b/app/routes/DocsManualRoute.res
@@ -1,0 +1,159 @@
+type loaderData = {
+  compiledMdx: CompiledMdx.t,
+  categories: array<SidebarLayout.Sidebar.Category.t>,
+  entries: array<TableOfContents.entry>,
+  title: string,
+  description: string,
+  filePath: string,
+}
+
+// Build sidebar categories from all manual docs, sorted by their "order" field in frontmatter
+let manualTableOfContents = async () => {
+  let groups =
+    (await MdxFile.loadAllAttributes(~dir="markdown-pages/docs"))
+    ->Mdx.filterMdxPages("docs/manual")
+    ->Mdx.groupBySection
+    ->Dict.mapValues(values =>
+      values->Mdx.sortSection->SidebarHelpers.convertToNavItems("/docs/manual")
+    )
+
+  SidebarHelpers.getAllGroups(
+    groups,
+    [
+      "Overview",
+      "Guides",
+      "Language Features",
+      "JavaScript Interop",
+      "Build System",
+      "Advanced Features",
+    ],
+  )
+}
+
+let loader: ReactRouter.Loader.t<loaderData> = async ({request}) => {
+  let {pathname} = WebAPI.URL.make(~url=request.url)
+  let filePath = MdxFile.resolveFilePath(
+    (pathname :> string),
+    ~dir="markdown-pages/docs/manual",
+    ~alias="docs/manual",
+  )
+
+  let raw = await Node.Fs.readFile(filePath, "utf-8")
+  let {frontmatter}: MarkdownParser.result = MarkdownParser.parseSync(raw)
+
+  let description = switch frontmatter {
+  | Object(dict) =>
+    switch dict->Dict.get("description") {
+    | Some(String(s)) => s
+    | _ => ""
+    }
+  | _ => ""
+  }
+
+  let title = switch frontmatter {
+  | Object(dict) =>
+    switch dict->Dict.get("title") {
+    | Some(String(s)) => s
+    | _ => ""
+    }
+  | _ => ""
+  }
+
+  let categories = await manualTableOfContents()
+
+  let compiledMdx = await MdxFile.compileMdx(raw, ~filePath, ~remarkPlugins=Mdx.plugins)
+
+  // Build table of contents entries from markdown headings
+  let markdownTree = Mdast.fromMarkdown(raw)
+  let tocResult = Mdast.toc(markdownTree, {maxDepth: 2})
+
+  let headers = Dict.make()
+  Mdast.reduceHeaders(tocResult.map, headers)
+
+  let entries =
+    headers
+    ->Dict.toArray
+    ->Array.map(((header, url)): TableOfContents.entry => {
+      header,
+      href: (url :> string),
+    })
+    ->Array.slice(~start=2) // skip document entry and H1 title, keep h2 sections
+
+  {
+    compiledMdx,
+    categories,
+    entries,
+    title: `${title} | ReScript Language Manual`,
+    description,
+    filePath,
+  }
+}
+
+let default = () => {
+  let {pathname} = ReactRouter.useLocation()
+  let {compiledMdx, categories, entries, title, description, filePath} = ReactRouter.useLoaderData()
+
+  let breadcrumbs = list{
+    {Url.name: "Docs", href: "/docs/manual/introduction"},
+    {
+      Url.name: "Language Manual",
+      href: "/docs/manual/introduction",
+    },
+  }
+
+  let editHref = `https://github.com/rescript-lang/rescript-lang.org/blob/master/${filePath}`
+
+  let sidebarContent =
+    <aside className="px-4 w-full block">
+      <div className="flex justify-between items-baseline">
+        <div className="flex flex-col text-fire font-medium">
+          <VersionSelect />
+        </div>
+        <button
+          className="flex items-center" onClick={_ => NavbarUtils.closeMobileTertiaryDrawer()}
+        >
+          <Icon.Close />
+        </button>
+      </div>
+      <div className="mb-56">
+        {categories
+        ->Array.map(category => {
+          let isItemActive = (navItem: SidebarLayout.Sidebar.NavItem.t) =>
+            navItem.href === (pathname :> string)
+          let getActiveToc = (navItem: SidebarLayout.Sidebar.NavItem.t) =>
+            if navItem.href === (pathname :> string) {
+              Some({TableOfContents.title, entries})
+            } else {
+              None
+            }
+          <div key=category.name>
+            <SidebarLayout.Sidebar.Category
+              isItemActive
+              getActiveToc
+              category
+              onClick={_ => NavbarUtils.closeMobileTertiaryDrawer()}
+            />
+          </div>
+        })
+        ->React.array}
+      </div>
+    </aside>
+
+  <>
+    <Meta title description />
+    <NavbarSecondary />
+    <NavbarTertiary sidebar=sidebarContent>
+      <SidebarLayout.BreadCrumbs crumbs=breadcrumbs />
+      <a
+        href=editHref className="inline text-14 hover:underline text-fire" rel="noopener noreferrer"
+      >
+        {React.string("Edit")}
+      </a>
+    </NavbarTertiary>
+    <DocsLayout categories activeToc={title, entries}>
+      <div className="markdown-body">
+        <MdxContent compiledMdx />
+      </div>
+    </DocsLayout>
+  </>
+}

--- a/app/routes/DocsManualRoute.res
+++ b/app/routes/DocsManualRoute.res
@@ -7,27 +7,36 @@ type loaderData = {
   filePath: string,
 }
 
-// Build sidebar categories from all manual docs, sorted by their "order" field in frontmatter
+// Module-level cache to avoid re-scanning frontmatter on every request
+let manualTableOfContentsCache: ref<option<array<SidebarLayout.Sidebar.Category.t>>> = ref(None)
+
+// Build sidebar categories from manual docs, sorted by their "order" field in frontmatter
 let manualTableOfContents = async () => {
-  let groups =
-    (await MdxFile.loadAllAttributes(~dir="markdown-pages/docs"))
-    ->Mdx.filterMdxPages("docs/manual")
-    ->Mdx.groupBySection
-    ->Dict.mapValues(values =>
-      values->Mdx.sortSection->SidebarHelpers.convertToNavItems("/docs/manual")
+  switch manualTableOfContentsCache.contents {
+  | Some(categories) => categories
+  | None =>
+    let groups =
+      (await MdxFile.loadAllAttributes(~dir="markdown-pages/docs/manual"))
+      ->SidebarHelpers.groupBySection
+      ->Dict.mapValues(values =>
+        values->SidebarHelpers.sortByOrder->SidebarHelpers.convertToNavItems("/docs/manual")
+      )
+
+    let categories = SidebarHelpers.getAllGroups(
+      groups,
+      [
+        "Overview",
+        "Guides",
+        "Language Features",
+        "JavaScript Interop",
+        "Build System",
+        "Advanced Features",
+      ],
     )
 
-  SidebarHelpers.getAllGroups(
-    groups,
-    [
-      "Overview",
-      "Guides",
-      "Language Features",
-      "JavaScript Interop",
-      "Build System",
-      "Advanced Features",
-    ],
-  )
+    manualTableOfContentsCache := Some(categories)
+    categories
+  }
 }
 
 let loader: ReactRouter.Loader.t<loaderData> = async ({request}) => {

--- a/app/routes/DocsManualRoute.resi
+++ b/app/routes/DocsManualRoute.resi
@@ -1,0 +1,12 @@
+type loaderData = {
+  compiledMdx: CompiledMdx.t,
+  categories: array<SidebarLayout.Sidebar.Category.t>,
+  entries: array<TableOfContents.entry>,
+  title: string,
+  description: string,
+  filePath: string,
+}
+
+let loader: ReactRouter.Loader.t<loaderData>
+
+let default: unit => React.element

--- a/app/routes/MdxRoute.res
+++ b/app/routes/MdxRoute.res
@@ -63,42 +63,6 @@ let convertToNavItems = (items, rootPath) =>
     }
   })
 
-let getGroup = (groups, groupName): SidebarLayout.Sidebar.Category.t => {
-  {
-    name: groupName,
-    items: groups
-    ->Dict.get(groupName)
-    ->Option.getOr([]),
-  }
-}
-
-let getAllGroups = (groups, groupNames): array<SidebarLayout.Sidebar.Category.t> =>
-  groupNames->Array.map(item => getGroup(groups, item))
-
-// These are the pages for the language manual, sorted by their "order" field in the frontmatter
-let manualTableOfContents = async () => {
-  let groups =
-    (await allMdx(~filterByPaths=["markdown-pages/docs"]))
-    ->filterMdxPages("docs/manual")
-    ->groupBySection
-    ->Dict.mapValues(values => values->sortSection->convertToNavItems("/docs/manual"))
-
-  // these are the categories that appear in the sidebar
-  let categories: array<SidebarLayout.Sidebar.Category.t> = getAllGroups(
-    groups,
-    [
-      "Overview",
-      "Guides",
-      "Language Features",
-      "JavaScript Interop",
-      "Build System",
-      "Advanced Features",
-    ],
-  )
-
-  categories
-}
-
 let reactTableOfContents = async () => {
   let groups =
     (await allMdx(~filterByPaths=["markdown-pages/docs"]))
@@ -107,7 +71,7 @@ let reactTableOfContents = async () => {
     ->Dict.mapValues(values => values->sortSection->convertToNavItems("/docs/react"))
 
   // these are the categories that appear in the sidebar
-  let categories: array<SidebarLayout.Sidebar.Category.t> = getAllGroups(
+  let categories: array<SidebarLayout.Sidebar.Category.t> = SidebarHelpers.getAllGroups(
     groups,
     ["Overview", "Main Concepts", "Hooks & State Management", "Guides"],
   )
@@ -123,7 +87,10 @@ let communityTableOfContents = async () => {
     ->Dict.mapValues(values => values->sortSection->convertToNavItems("/community"))
 
   // these are the categories that appear in the sidebar
-  let categories: array<SidebarLayout.Sidebar.Category.t> = getAllGroups(groups, ["Resources"])
+  let categories: array<SidebarLayout.Sidebar.Category.t> = SidebarHelpers.getAllGroups(
+    groups,
+    ["Resources"],
+  )
 
   categories
 }
@@ -161,8 +128,6 @@ let loader: ReactRouter.Loader.t<loaderData> = async ({request}) => {
     let categories = {
       if pathname == "/docs/manual/api" {
         []
-      } else if pathname->String.includes("docs/manual") {
-        await manualTableOfContents()
       } else if pathname->String.includes("docs/react") {
         await reactTableOfContents()
       } else if pathname->String.includes("community") {
@@ -214,22 +179,14 @@ let loader: ReactRouter.Loader.t<loaderData> = async ({request}) => {
       ->Array.slice(~start=2) // skip first two entries which are the document entry and the H1 title for the page, we just want the h2 sections
 
     let breadcrumbs =
-      pathname->String.includes("docs/manual")
+      pathname->String.includes("docs/react")
         ? Some(list{
             {Url.name: "Docs", href: "/docs/"},
             {
-              Url.name: "Language Manual",
-              href: "/docs/manual/" ++ "introduction",
+              Url.name: "rescript-react",
+              href: "/docs/react/" ++ "introduction",
             },
           })
-        : pathname->String.includes("docs/react")
-        ? Some(list{
-          {Url.name: "Docs", href: "/docs/"},
-          {
-            Url.name: "rescript-react",
-            href: "/docs/react/" ++ "introduction",
-          },
-        })
         : None
 
     let metaTitleCategory = {
@@ -238,8 +195,6 @@ let loader: ReactRouter.Loader.t<loaderData> = async ({request}) => {
         "ReScript React"
       } else if path->String.includes("docs/manual/api") {
         "ReScript API"
-      } else if path->String.includes("docs/manual") {
-        "ReScript Language Manual"
       } else if path->String.includes("community") {
         "ReScript Community"
       } else {
@@ -321,9 +276,8 @@ let default = () => {
         </ApiOverviewLayout.Docs>
       </>
     } else if (
-      (pathname :> string)->String.includes("docs/manual") ||
       (pathname :> string)->String.includes("docs/react") ||
-      (pathname :> string)->String.includes("docs/guidelines")
+        (pathname :> string)->String.includes("docs/guidelines")
     ) {
       <>
         <Meta title=title description={attributes.description->Nullable.getOr("")} />
@@ -332,9 +286,7 @@ let default = () => {
           let breadcrumbs = loaderData.breadcrumbs->Option.map(crumbs =>
             List.mapWithIndex(crumbs, (item, index) => {
               if index === 0 {
-                if (pathname :> string)->String.includes("docs/manual") {
-                  {...item, href: "/docs/manual/introduction"}
-                } else if (pathname :> string)->String.includes("docs/react") {
+                if (pathname :> string)->String.includes("docs/react") {
                   {...item, href: "/docs/react/introduction"}
                 } else {
                   item

--- a/src/MdxFile.res
+++ b/src/MdxFile.res
@@ -39,7 +39,7 @@ let resolveFilePath = (pathname, ~dir, ~alias) => {
   } else {
     path
   }
-  relativePath ++ ".mdx"
+  relativePath->String.replaceAll("\\", "/") ++ ".mdx"
 }
 
 let loadFile = async filePath => {
@@ -73,4 +73,34 @@ let scanPaths = (~dir, ~alias) => {
   scanDir(dir, dir)->Array.map(relativePath => {
     alias ++ "/" ++ relativePath
   })
+}
+
+// Convert frontmatter JSON dict to Mdx.attributes
+// This is the same unsafe approach as react-router-mdx — frontmatter YAML
+// becomes a JS object that we type as Mdx.attributes. Fields not present
+// in the frontmatter (e.g. blog-specific `author`, `date`) are undefined at
+// runtime, which is fine because docs/community code never accesses them.
+external dictToAttributes: Dict.t<JSON.t> => Mdx.attributes = "%identity"
+
+let loadAllAttributes = async (~dir) => {
+  let files = scanDir(dir, dir)
+  await Promise.all(
+    files->Array.map(async relativePath => {
+      let fullPath = Node.Path.join2(dir, relativePath ++ ".mdx")->String.replaceAll("\\", "/")
+      let raw = await Node.Fs.readFile(fullPath, "utf-8")
+      let {frontmatter}: MarkdownParser.result = MarkdownParser.parseSync(raw)
+
+      let dict = switch frontmatter {
+      | Object(dict) => dict
+      | _ => Dict.make()
+      }
+
+      // Add path and slug fields (same as react-router-mdx does)
+      dict->Dict.set("path", JSON.String(fullPath))
+      let slug = Node.Path.basename(relativePath)
+      dict->Dict.set("slug", JSON.String(slug))
+
+      dictToAttributes(dict)
+    }),
+  )
 }

--- a/src/MdxFile.res
+++ b/src/MdxFile.res
@@ -75,12 +75,25 @@ let scanPaths = (~dir, ~alias) => {
   })
 }
 
-// Convert frontmatter JSON dict to Mdx.attributes
-// This is the same unsafe approach as react-router-mdx — frontmatter YAML
-// becomes a JS object that we type as Mdx.attributes. Fields not present
-// in the frontmatter (e.g. blog-specific `author`, `date`) are undefined at
-// runtime, which is fine because docs/community code never accesses them.
-external dictToAttributes: Dict.t<JSON.t> => Mdx.attributes = "%identity"
+type sidebarEntry = {
+  title: string,
+  slug: option<string>,
+  section: option<string>,
+  order: option<int>,
+  path: option<string>,
+}
+
+let jsonToString = json =>
+  switch json {
+  | JSON.String(s) => Some(s)
+  | _ => None
+  }
+
+let jsonToInt = json =>
+  switch json {
+  | JSON.Number(n) => Some(Float.toInt(n))
+  | _ => None
+  }
 
 let loadAllAttributes = async (~dir) => {
   let files = scanDir(dir, dir)
@@ -95,12 +108,13 @@ let loadAllAttributes = async (~dir) => {
       | _ => Dict.make()
       }
 
-      // Add path and slug fields (same as react-router-mdx does)
-      dict->Dict.set("path", JSON.String(fullPath))
-      let slug = Node.Path.basename(relativePath)
-      dict->Dict.set("slug", JSON.String(slug))
-
-      dictToAttributes(dict)
+      {
+        title: dict->Dict.get("title")->Option.flatMap(jsonToString)->Option.getOr(""),
+        slug: Some(Node.Path.basename(relativePath)),
+        section: dict->Dict.get("section")->Option.flatMap(jsonToString),
+        order: dict->Dict.get("order")->Option.flatMap(jsonToInt),
+        path: Some(fullPath),
+      }
     }),
   )
 }

--- a/src/MdxFile.resi
+++ b/src/MdxFile.resi
@@ -24,3 +24,9 @@ let compileMdx: (
   ~filePath: string,
   ~remarkPlugins: array<Mdx.remarkPlugin>=?,
 ) => promise<CompiledMdx.t>
+
+/** Scan all .mdx files in a directory, parse frontmatter only, and return
+ * as Mdx.attributes with `path` and `slug` fields populated.
+ * Replaces `react-router-mdx`'s `loadAllMdx`.
+ */
+let loadAllAttributes: (~dir: string) => promise<array<Mdx.attributes>>

--- a/src/MdxFile.resi
+++ b/src/MdxFile.resi
@@ -25,8 +25,19 @@ let compileMdx: (
   ~remarkPlugins: array<Mdx.remarkPlugin>=?,
 ) => promise<CompiledMdx.t>
 
-/** Scan all .mdx files in a directory, parse frontmatter only, and return
- * as Mdx.attributes with `path` and `slug` fields populated.
- * Replaces `react-router-mdx`'s `loadAllMdx`.
+/** Lightweight frontmatter record containing only the fields needed for
+ * sidebar navigation. Unlike Mdx.attributes, every field is either
+ * optional or has a safe default, so no unsafe casting is required.
  */
-let loadAllAttributes: (~dir: string) => promise<array<Mdx.attributes>>
+type sidebarEntry = {
+  title: string,
+  slug: option<string>,
+  section: option<string>,
+  order: option<int>,
+  path: option<string>,
+}
+
+/** Scan all .mdx files in a directory, parse frontmatter only, and return
+ * sidebar entries with `path` and `slug` fields populated.
+ */
+let loadAllAttributes: (~dir: string) => promise<array<sidebarEntry>>

--- a/src/SidebarHelpers.res
+++ b/src/SidebarHelpers.res
@@ -1,0 +1,23 @@
+let convertToNavItems = (items, rootPath) =>
+  Array.map(items, (item): SidebarLayout.Sidebar.NavItem.t => {
+    let href = switch item.Mdx.slug {
+    | Some(slug) => `${rootPath}/${slug}`
+    | None => rootPath
+    }
+    {
+      name: item.title,
+      href,
+    }
+  })
+
+let getGroup = (groups, groupName): SidebarLayout.Sidebar.Category.t => {
+  {
+    name: groupName,
+    items: groups
+    ->Dict.get(groupName)
+    ->Option.getOr([]),
+  }
+}
+
+let getAllGroups = (groups, groupNames): array<SidebarLayout.Sidebar.Category.t> =>
+  groupNames->Array.map(item => getGroup(groups, item))

--- a/src/SidebarHelpers.res
+++ b/src/SidebarHelpers.res
@@ -1,6 +1,29 @@
-let convertToNavItems = (items, rootPath) =>
+let filterByPath = (entries: array<MdxFile.sidebarEntry>, path) =>
+  Array.filter(entries, entry =>
+    entry.path->Option.map(String.includes(_, path))->Option.getOr(false)
+  )
+
+let sortByOrder = (entries: array<MdxFile.sidebarEntry>) =>
+  Array.toSorted(entries, (a, b) =>
+    switch (a.order, b.order) {
+    | (Some(a), Some(b)) => a > b ? 1.0 : -1.0
+    | _ => -1.0
+    }
+  )
+
+let groupBySection = (entries: array<MdxFile.sidebarEntry>) =>
+  Array.reduce(entries, (Dict.make() :> Dict.t<array<MdxFile.sidebarEntry>>), (acc, item) => {
+    let section = item.section->Option.flatMap(Dict.get(acc, _))
+    switch section {
+    | Some(section) => section->Array.push(item)
+    | None => item.section->Option.forEach(section => acc->Dict.set(section, [item]))
+    }
+    acc
+  })
+
+let convertToNavItems = (items: array<MdxFile.sidebarEntry>, rootPath) =>
   Array.map(items, (item): SidebarLayout.Sidebar.NavItem.t => {
-    let href = switch item.Mdx.slug {
+    let href = switch item.slug {
     | Some(slug) => `${rootPath}/${slug}`
     | None => rootPath
     }

--- a/src/SidebarHelpers.resi
+++ b/src/SidebarHelpers.resi
@@ -1,0 +1,14 @@
+/** Convert Mdx.attributes to sidebar nav items, building hrefs from rootPath + slug. */
+let convertToNavItems: (array<Mdx.attributes>, string) => array<SidebarLayout.Sidebar.NavItem.t>
+
+/** Get a single sidebar category by name from a dict of grouped nav items. */
+let getGroup: (
+  Dict.t<array<SidebarLayout.Sidebar.NavItem.t>>,
+  string,
+) => SidebarLayout.Sidebar.Category.t
+
+/** Get multiple sidebar categories by name from a dict of grouped nav items. */
+let getAllGroups: (
+  Dict.t<array<SidebarLayout.Sidebar.NavItem.t>>,
+  array<string>,
+) => array<SidebarLayout.Sidebar.Category.t>

--- a/src/SidebarHelpers.resi
+++ b/src/SidebarHelpers.resi
@@ -1,5 +1,17 @@
-/** Convert Mdx.attributes to sidebar nav items, building hrefs from rootPath + slug. */
-let convertToNavItems: (array<Mdx.attributes>, string) => array<SidebarLayout.Sidebar.NavItem.t>
+/** Filter sidebar entries whose path contains the given substring. */
+let filterByPath: (array<MdxFile.sidebarEntry>, string) => array<MdxFile.sidebarEntry>
+
+/** Sort sidebar entries by their `order` field (ascending). */
+let sortByOrder: array<MdxFile.sidebarEntry> => array<MdxFile.sidebarEntry>
+
+/** Group sidebar entries by their `section` field into a dict. */
+let groupBySection: array<MdxFile.sidebarEntry> => Dict.t<array<MdxFile.sidebarEntry>>
+
+/** Convert sidebar entries to nav items, building hrefs from rootPath + slug. */
+let convertToNavItems: (
+  array<MdxFile.sidebarEntry>,
+  string,
+) => array<SidebarLayout.Sidebar.NavItem.t>
 
 /** Get a single sidebar category by name from a dict of grouped nav items. */
 let getGroup: (


### PR DESCRIPTION
- Add DocsManualRoute for /docs/manual pages with sidebar and TOC
- Implement SidebarHelpers for sidebar nav/category generation
- Add MdxFile.loadAllAttributes for loading manual doc frontmatter
- Update routes to support manual docs and exclude from mdxRoutes
- Document commit/PR conventions in AGENTS.md

> [!NOTE]
> This work was done with AI assistance