### PR TITLE
feat: split community pages out of MdxRoute into CommunityRoute

### DIFF
--- a/app/routes.res
+++ b/app/routes.res
@@ -33,10 +33,20 @@ let blogArticleRoutes =
     route(path, "./routes/BlogArticleRoute.jsx", ~options={id: path})
   )
 
+let communityRoutes =
+  MdxFile.scanPaths(~dir="markdown-pages/community", ~alias="community")->Array.map(path =>
+    route(path, "./routes/CommunityRoute.jsx", ~options={id: path})
+  )
+
 let mdxRoutes = mdxRoutes("./routes/MdxRoute.jsx")->Array.filter(r =>
   !(
     r.path
-    ->Option.map(path => path === "blog" || String.startsWith(path, "blog/"))
+    ->Option.map(path =>
+      path === "blog" ||
+      String.startsWith(path, "blog/") ||
+      path === "community" ||
+      String.startsWith(path, "community/")
+    )
     ->Option.getOr(false)
   )
 )
@@ -56,6 +66,7 @@ let default = [
   ...stdlibRoutes,
   ...beltRoutes,
   ...blogArticleRoutes,
+  ...communityRoutes,
   ...mdxRoutes,
   route("*", "./routes/NotFoundRoute.jsx"),
 ]

--- a/app/routes/CommunityRoute.res
+++ b/app/routes/CommunityRoute.res
@@ -1,0 +1,119 @@
+type loaderData = {
+  compiledMdx: CompiledMdx.t,
+  entries: array<TableOfContents.entry>,
+  title: string,
+  description: string,
+  filePath: string,
+  categories: array<SidebarLayout.Sidebar.Category.t>,
+}
+
+let convertToNavItems = (items, rootPath) =>
+  Array.map(items, (item): SidebarLayout.Sidebar.NavItem.t => {
+    let href = switch item.Mdx.slug {
+    | Some(slug) => `${rootPath}/${slug}`
+    | None => rootPath
+    }
+    {
+      name: item.title,
+      href,
+    }
+  })
+
+let getGroup = (groups, groupName): SidebarLayout.Sidebar.Category.t => {
+  {
+    name: groupName,
+    items: groups
+    ->Dict.get(groupName)
+    ->Option.getOr([]),
+  }
+}
+
+let getAllGroups = (groups, groupNames): array<SidebarLayout.Sidebar.Category.t> =>
+  groupNames->Array.map(item => getGroup(groups, item))
+
+let communityTableOfContents = async () => {
+  let groups =
+    (await Mdx.allMdx(~filterByPaths=["markdown-pages/community"]))
+    ->Mdx.filterMdxPages("community")
+    ->Mdx.groupBySection
+    ->Dict.mapValues(values => values->Mdx.sortSection->convertToNavItems("/community"))
+
+  getAllGroups(groups, ["Resources"])
+}
+
+let loader: ReactRouter.Loader.t<loaderData> = async ({request}) => {
+  let {pathname} = WebAPI.URL.make(~url=request.url)
+  let filePath = MdxFile.resolveFilePath(
+    (pathname :> string),
+    ~dir="markdown-pages/community",
+    ~alias="community",
+  )
+
+  let raw = await Node.Fs.readFile(filePath, "utf-8")
+  let {frontmatter}: MarkdownParser.result = MarkdownParser.parseSync(raw)
+
+  let description = switch frontmatter {
+  | Object(dict) =>
+    switch dict->Dict.get("description") {
+    | Some(String(s)) => s
+    | _ => ""
+    }
+  | _ => ""
+  }
+
+  let title = switch frontmatter {
+  | Object(dict) =>
+    switch dict->Dict.get("title") {
+    | Some(String(s)) => s
+    | _ => ""
+    }
+  | _ => ""
+  }
+
+  let compiledMdx = await MdxFile.compileMdx(raw, ~filePath, ~remarkPlugins=Mdx.plugins)
+
+  let markdownTree = Mdast.fromMarkdown(raw)
+  let tocResult = Mdast.toc(markdownTree, {maxDepth: 2})
+
+  let headers = Dict.make()
+  Mdast.reduceHeaders(tocResult.map, headers)
+
+  let entries =
+    headers
+    ->Dict.toArray
+    ->Array.map(((header, url)): TableOfContents.entry => {
+      header,
+      href: (url :> string),
+    })
+    ->Array.slice(~start=2)
+
+  let categories = await communityTableOfContents()
+
+  {
+    compiledMdx,
+    entries,
+    title: `${title} | ReScript Community`,
+    description,
+    filePath,
+    categories,
+  }
+}
+
+let default = () => {
+  let {compiledMdx, entries, filePath, categories} = ReactRouter.useLoaderData()
+
+  let editHref = `https://github.com/rescript-lang/rescript-lang.org/blob/master/${filePath}`
+
+  <>
+    <CommunityLayout categories entries>
+      <div className="markdown-body">
+        <MdxContent compiledMdx />
+      </div>
+      <a
+        href=editHref className="inline text-14 hover:underline text-fire" rel="noopener noreferrer"
+      >
+        {React.string("Edit")}
+      </a>
+    </CommunityLayout>
+  </>
+}

--- a/app/routes/MdxRoute.res
+++ b/app/routes/MdxRoute.res
@@ -115,19 +115,6 @@ let reactTableOfContents = async () => {
   categories
 }
 
-let communityTableOfContents = async () => {
-  let groups =
-    (await allMdx(~filterByPaths=["markdown-pages/community"]))
-    ->filterMdxPages("community")
-    ->groupBySection
-    ->Dict.mapValues(values => values->sortSection->convertToNavItems("/community"))
-
-  // these are the categories that appear in the sidebar
-  let categories: array<SidebarLayout.Sidebar.Category.t> = getAllGroups(groups, ["Resources"])
-
-  categories
-}
-
 let loader: ReactRouter.Loader.t<loaderData> = async ({request}) => {
   let {pathname} = WebAPI.URL.make(~url=request.url)
 
@@ -165,8 +152,6 @@ let loader: ReactRouter.Loader.t<loaderData> = async ({request}) => {
         await manualTableOfContents()
       } else if pathname->String.includes("docs/react") {
         await reactTableOfContents()
-      } else if pathname->String.includes("community") {
-        await communityTableOfContents()
       } else {
         []
       }
@@ -240,8 +225,6 @@ let loader: ReactRouter.Loader.t<loaderData> = async ({request}) => {
         "ReScript API"
       } else if path->String.includes("docs/manual") {
         "ReScript Language Manual"
-      } else if path->String.includes("community") {
-        "ReScript Community"
       } else {
         "ReScript"
       }
@@ -402,10 +385,6 @@ let default = () => {
           </>
         }
       </>
-    } else if (pathname :> string)->String.includes("community") {
-      <CommunityLayout categories entries>
-        <div className="markdown-body"> {component()} </div>
-      </CommunityLayout>
     } else {
       switch loaderData.mdxSources {
       | Some(mdxSources) =>


### PR DESCRIPTION
- Create CommunityRoute.res with dedicated loader and community sidebar
- Register communityRoutes in routes.res, filter community from mdxRoutes
- Remove communityTableOfContents, community branches from MdxRoute

> [!NOTE]
> This work was done with AI assistance