### PR TITLE
feat: split out docs/guidelines routes from shared MdxRoute file

### DIFF
--- a/app/routes.res
+++ b/app/routes.res
@@ -33,10 +33,21 @@ let blogArticleRoutes =
     route(path, "./routes/BlogArticleRoute.jsx", ~options={id: path})
   )
 
+let docsGuidelinesRoutes =
+  MdxFile.scanPaths(
+    ~dir="markdown-pages/docs/guidelines",
+    ~alias="docs/guidelines",
+  )->Array.map(path => route(path, "./routes/DocsGuidelinesRoute.jsx", ~options={id: path}))
+
 let mdxRoutes = mdxRoutes("./routes/MdxRoute.jsx")->Array.filter(r =>
   !(
     r.path
-    ->Option.map(path => path === "blog" || String.startsWith(path, "blog/"))
+    ->Option.map(path =>
+      path === "blog" ||
+      String.startsWith(path, "blog/") ||
+      path === "docs/guidelines" ||
+      String.startsWith(path, "docs/guidelines/")
+    )
     ->Option.getOr(false)
   )
 )
@@ -56,6 +67,7 @@ let default = [
   ...stdlibRoutes,
   ...beltRoutes,
   ...blogArticleRoutes,
+  ...docsGuidelinesRoutes,
   ...mdxRoutes,
   route("*", "./routes/NotFoundRoute.jsx"),
 ]

--- a/app/routes/DocsGuidelinesRoute.res
+++ b/app/routes/DocsGuidelinesRoute.res
@@ -1,0 +1,88 @@
+type loaderData = {
+  compiledMdx: CompiledMdx.t,
+  entries: array<TableOfContents.entry>,
+  title: string,
+  description: string,
+  filePath: string,
+}
+
+let loader: ReactRouter.Loader.t<loaderData> = async ({request}) => {
+  let {pathname} = WebAPI.URL.make(~url=request.url)
+  let filePath = MdxFile.resolveFilePath(
+    (pathname :> string),
+    ~dir="markdown-pages/docs/guidelines",
+    ~alias="docs/guidelines",
+  )
+
+  let raw = await Node.Fs.readFile(filePath, "utf-8")
+  let {frontmatter}: MarkdownParser.result = MarkdownParser.parseSync(raw)
+
+  let description = switch frontmatter {
+  | Object(dict) =>
+    switch dict->Dict.get("description") {
+    | Some(String(s)) => s
+    | _ => ""
+    }
+  | _ => ""
+  }
+
+  let title = switch frontmatter {
+  | Object(dict) =>
+    switch dict->Dict.get("title") {
+    | Some(String(s)) => s
+    | _ => ""
+    }
+  | _ => ""
+  }
+
+  let compiledMdx = await MdxFile.compileMdx(raw, ~filePath, ~remarkPlugins=Mdx.plugins)
+
+  // Build table of contents entries from markdown headings
+  let markdownTree = Mdast.fromMarkdown(raw)
+  let tocResult = Mdast.toc(markdownTree, {maxDepth: 2})
+
+  let headers = Dict.make()
+  Mdast.reduceHeaders(tocResult.map, headers)
+
+  let entries =
+    headers
+    ->Dict.toArray
+    ->Array.map(((header, url)): TableOfContents.entry => {
+      header,
+      href: (url :> string),
+    })
+    ->Array.slice(~start=2) // skip document entry and H1 title, keep h2 sections
+
+  {
+    compiledMdx,
+    entries,
+    title: `${title} | ReScript Guidelines`,
+    description,
+    filePath,
+  }
+}
+
+let default = () => {
+  let {compiledMdx, entries, title, description, filePath} = ReactRouter.useLoaderData()
+
+  let editHref = `https://github.com/rescript-lang/rescript-lang.org/blob/master/${filePath}`
+
+  let categories: array<SidebarLayout.Sidebar.Category.t> = []
+
+  <>
+    <Meta title description />
+    <NavbarSecondary />
+    <NavbarTertiary>
+      <a
+        href=editHref className="inline text-14 hover:underline text-fire" rel="noopener noreferrer"
+      >
+        {React.string("Edit")}
+      </a>
+    </NavbarTertiary>
+    <DocsLayout categories activeToc={title, entries}>
+      <div className="markdown-body">
+        <MdxContent compiledMdx />
+      </div>
+    </DocsLayout>
+  </>
+}

--- a/app/routes/DocsGuidelinesRoute.resi
+++ b/app/routes/DocsGuidelinesRoute.resi
@@ -1,0 +1,11 @@
+type loaderData = {
+  compiledMdx: CompiledMdx.t,
+  entries: array<TableOfContents.entry>,
+  title: string,
+  description: string,
+  filePath: string,
+}
+
+let loader: ReactRouter.Loader.t<loaderData>
+
+let default: unit => React.element


### PR DESCRIPTION
This pull request adds support for a new "docs/guidelines" section to the documentation site. It introduces a dedicated route and loader for guideline pages, ensures proper routing and filtering, and updates the layout to match other documentation sections.

**Routing and page loading:**

* Added a new route handler `DocsGuidelinesRoute` with a corresponding loader to render markdown files from `markdown-pages/docs/guidelines`, extract metadata, build a table of contents, and set up the page layout. (`app/routes/DocsGuidelinesRoute.res`, `app/routes/DocsGuidelinesRoute.resi`) [[1]](diffhunk://#diff-80040c2c000d58e1c5a397e504a28cfc9fb660c098f9e557973db52bfa5489c4R1-R88) [[2]](diffhunk://#diff-8095a4fa30b106d345a927ed7a80a4f9ec1cea744c3c66228a4125167165edd9R1-R11)
* Updated the main routes configuration to scan and include all guideline markdown files as routes, similar to how manual and react docs are handled. (`app/routes.res`) [[1]](diffhunk://#diff-9b5cc706a2c6b1c3adde0d827f1dd4a5062f855577b82ccba79d3c7a8fadb732R46-R51) [[2]](diffhunk://#diff-9b5cc706a2c6b1c3adde0d827f1dd4a5062f855577b82ccba79d3c7a8fadb732R86)

**Routing logic and filtering:**

* Modified the MDX routes filter to exclude "docs/guidelines" paths from generic MDX handling, ensuring they are handled by the new dedicated route. (`app/routes.res`)
* Updated the fallback logic in `MdxRoute` to properly handle "docs/guidelines" paths, so they render with the correct layout when matched. (`app/routes/MdxRoute.res`)
* 
> [!NOTE]
> This work was done with AI assistance