### PR TITLE
ci: allow dependabot PRs to skip deployments to cloudflare

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,6 @@ on:
         required: true
         default: "preview"
   pull_request:
-  pull_request_target:
 
 jobs:
   deploy:
@@ -20,18 +19,13 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.fork == false &&
-       github.actor != 'dependabot[bot]') ||
-      (github.event_name == 'pull_request_target' &&
-       github.actor == 'dependabot[bot]')
+       github.event.pull_request.head.repo.fork == false)
     permissions:
       contents: read
       deployments: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v6.0.2
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
       - name: Setup Node.js environment
         uses: actions/setup-node@v6.3.0
         with:
@@ -63,6 +57,7 @@ jobs:
         env:
           VITE_DEPLOYMENT_URL: ${{ env.VITE_DEPLOYMENT_URL }}
       - name: Deploy
+        if: github.actor != 'dependabot[bot]'
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
@@ -74,6 +69,7 @@ jobs:
         env:
           FORCE_COLOR: 0
       - name: Comment PR with deployment link
+        if: github.actor != 'dependabot[bot]'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,11 +15,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy
-    if: >-
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.fork == false)
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           VITE_DEPLOYMENT_URL: ${{ env.VITE_DEPLOYMENT_URL }}
       - name: Deploy
-        if: github.actor != 'dependabot[bot]'
+        if: ${{ github.actor != 'dependabot[bot]' }}
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
@@ -65,7 +65,7 @@ jobs:
         env:
           FORCE_COLOR: 0
       - name: Comment PR with deployment link
-        if: github.actor != 'dependabot[bot]'
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,11 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6.0.2
+        if: github.event_name == 'pull_request_target'
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v6.0.2
+        if: github.event_name != 'pull_request_target'
       - name: Setup Node.js environment
         uses: actions/setup-node@v6.3.0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,18 +10,28 @@ on:
         required: true
         default: "preview"
   pull_request:
+  pull_request_target:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.fork == false &&
+       github.actor != 'dependabot[bot]') ||
+      (github.event_name == 'pull_request_target' &&
+       github.actor == 'dependabot[bot]')
     permissions:
       contents: read
       deployments: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
       - name: Setup yarn
         uses: actions/setup-node@v3
         with:
@@ -40,9 +50,9 @@ jobs:
              echo "VITE_DEPLOYMENT_URL=" >> "$GITHUB_ENV"
           else
              SAFE_BRANCH="${RAW_BRANCH//\//-}"
-             
+
              SAFE_BRANCH=$(echo "$SAFE_BRANCH" | tr '[:upper:]' '[:lower:]')
-             
+
              echo "SAFE_BRANCH=$SAFE_BRANCH" >> "$GITHUB_ENV"
              echo "VITE_DEPLOYMENT_URL=https://${SAFE_BRANCH}.rescript-lang.pages.dev" >> "$GITHUB_ENV"
           fi


### PR DESCRIPTION
<img width="766" height="369" alt="image" src="https://github.com/user-attachments/assets/7827d037-2dff-4441-943d-d5ba59488a8b" />

This pull request updates the deployment workflow to prevent certain steps from running when the workflow is triggered by Dependabot. Specifically, the deployment and pull request comment steps will now be skipped if the actor is Dependabot.

Workflow condition updates:

* Added a condition to the "Deploy" step in `.github/workflows/deploy.yml` so it does not run when the workflow is triggered by `dependabot[bot]`.
* Added a similar condition to the "Comment PR with deployment link" step to skip commenting when triggered by `dependabot[bot]`.