### PR TITLE
fix: Add .resi file for CommunityRoute.jsx

### DIFF
--- a/app/routes/CommunityRoute.resi
+++ b/app/routes/CommunityRoute.resi
@@ -1,0 +1,12 @@
+type loaderData = {
+  compiledMdx: CompiledMdx.t,
+  entries: array<TableOfContents.entry>,
+  title: string,
+  description: string,
+  filePath: string,
+  categories: array<SidebarLayout.Sidebar.Category.t>,
+}
+
+let loader: ReactRouter.Loader.t<loaderData>
+
+let default: unit => React.element


### PR DESCRIPTION
By omitting the `.resi` file from this route it causes in app navigation to that page to not work due to the extra exports that React Router is not expecting. I'm surprised that it builds with the pre-render but the actual routing doesn't work after the build.