### PR TITLE
docs: document external stdlib and add version notes for arrays and suffix

### DIFF
--- a/markdown-pages/blog/release-9-0.mdx
+++ b/markdown-pages/blog/release-9-0.mdx
@@ -34,7 +34,7 @@ Our compiler comes with a set of stdlib modules (such as `Belt`, `Pervasives`, e
 
 In previous versions, users couldn't ship their compiled JS code without defining a `package.json` dependency on `bs-platform`. Whenever a ReScript developer wanted to publish a package just for pure JS consumption / lean container deployment, they were required to use a bundler to bundle up their library / stdlib code, which made things way more complex and harder to understand.
 
-To fix this problem, we introduced an `external-stdlib` configuration that allows specifying a pre-compiled stdlib npm package (`@rescript/std`).
+To fix this problem, we introduced an `external-stdlib` configuration that allows specifying a pre-compiled stdlib npm package (`@rescript/std`). More details on how to use that feature can be found in our [External Stdlib](../docs/manual/build-external-stdlib.mdx) documentation.
 
 ### Less Bundle Bloat when Adding ReScript
 

--- a/markdown-pages/docs/manual/array-and-list.mdx
+++ b/markdown-pages/docs/manual/array-and-list.mdx
@@ -82,6 +82,8 @@ myArray[0] = "bye";
 
 ### Array spreads
 
+**Since 11.1**
+
 You can spread arrays of the same type into new arrays:
 
 <CodeTab labels={["ReScript", "JS Output"]}>

--- a/markdown-pages/docs/manual/build-configuration.mdx
+++ b/markdown-pages/docs/manual/build-configuration.mdx
@@ -149,9 +149,14 @@ Output to either CommonJS (the default) or JavaScript module. Example:
 
 This configuration only applies to you, when you develop the project. When the project is used as a third-party library, the consumer's own `rescript.json` `package-specs` overrides the configuration here, logically.
 
+## external-stdlib
+
+**Since 9.0**: This setting allows depending on an externally built stdlib package (instead of a locally built stdlib runtime). Useful for shipping packages that are only consumed in JS or TS without any dependencies to the ReScript development toolchain.
+
 ## suffix
 
-The suffix can be freely chosen. However, we still suggest you stick to the convention and use
+**Since 11.0**: The suffix can be freely chosen. However, we still suggest you stick to the convention and use
+
 one of the following:
 
 - `".js`


### PR DESCRIPTION
### Motivation

- Clarify usage and discovery of the new external stdlib feature so authors can ship precompiled stdlib packages for JS-only consumers. 
- Surface version information for smaller language/stdlib changes so readers know when features became available. 

### Description

- Added a link in the ReScript 9.0 release blog post to the External Stdlib documentation (`docs/manual/build-external-stdlib.mdx`).
- Introduced an `external-stdlib` section to the build configuration docs with a `Since 9.0` note describing its purpose for depending on an externally built stdlib package.
- Added `Since 11.0` metadata to the `suffix` section to indicate when the documented behavior applies.
- Added a `Since 11.1` note above the Array spreads example in the array-and-list documentation to document when the spread behavior became available.

### Testing

- Built the documentation site locally to verify the modified MDX files compile without errors and links resolve, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ad428d2c832aa32e82098e568f65)