### PR TITLE
docs: note pnpm hoisting caveat for @rescript/runtime

### DIFF
--- a/markdown-pages/docs/manual/installation.mdx
+++ b/markdown-pages/docs/manual/installation.mdx
@@ -133,6 +133,15 @@ bun create rescript-app
 
   </CodeTab>
 
+  <Info>
+    **pnpm users:** ReScript-compiled JS imports from `@rescript/runtime` directly, but pnpm's strict isolation does not expose transitive dependencies at the app root. Either install the runtime as a direct dependency (`pnpm add @rescript/runtime`), or hoist it by adding the following to `pnpm-workspace.yaml`:
+
+    ```yaml
+    publicHoistPattern:
+      - "*@rescript/runtime*"
+    ```
+  </Info>
+
 - Create a ReScript build configuration file (called `rescript.json`) at the root:
   ```json
   {

--- a/markdown-pages/docs/manual/migrate-to-v12.mdx
+++ b/markdown-pages/docs/manual/migrate-to-v12.mdx
@@ -51,7 +51,17 @@ if you had `@rescript/std` installed, remove it as well:
 npm uninstall @rescript/std
 ```
 
-this is replaced by `@rescript/runtime`, which is a installed as a dependency of `rescript` now.
+this is replaced by `@rescript/runtime`, which is installed as a dependency of `rescript` now.
+
+<Info>
+  **pnpm users:** since pnpm does not hoist transitive dependencies, you may need to install `@rescript/runtime` as a direct dependency (`pnpm add @rescript/runtime`), or hoist it by adding the following to `pnpm-workspace.yaml`:
+
+```yaml
+publicHoistPattern:
+  - "*@rescript/runtime*"
+```
+
+</Info>
 
 ## Replacements
 


### PR DESCRIPTION
pnpm's strict isolation does not expose transitive dependencies at the app root, so ReScript-compiled JS importing @rescript/runtime fails to resolve. Add a callout to the installation and v12 migration docs explaining the two workarounds (direct install or publicHoistPattern in pnpm-workspace.yaml) and fix a small typo while at it.

Related issue: https://github.com/rescript-lang/rescript/issues/8357