### PR TITLE
fix: fix contrast on playground settings text

### DIFF
--- a/src/Playground.res
+++ b/src/Playground.res
@@ -81,7 +81,7 @@ module SelectionOption = {
       className={"playground-selection-option mr-1 px-2 py-1 rounded inline-block " ++ if isActive {
         "playground-selection-option-active font-bold"
       } else {
-        "opacity-50 hover:opacity-80"
+        "opacity-90 hover:opacity-100"
       }}
       onClick
       disabled

--- a/styles/main.css
+++ b/styles/main.css
@@ -311,17 +311,17 @@
   }
 
   .playground-text-primary {
-    color: var(--playground-text-primary);
+    color: var(--playground-text-primary) !important;
   }
 
   .playground-text-secondary {
-    color: var(--playground-text-secondary);
+    color: var(--playground-text-secondary) !important;
   }
 
   .playground-select {
     background-color: var(--playground-elevated-bg);
     border-color: var(--playground-border);
-    color: var(--playground-text-primary);
+    color: var(--playground-text-primary) !important;
   }
 
   .playground-selection-option {


### PR DESCRIPTION
## Before
<img width="906" height="652" alt="image" src="https://github.com/user-attachments/assets/800a77f9-50a4-49bc-a5d7-cae3df42af20" />

<img width="883" height="654" alt="image" src="https://github.com/user-attachments/assets/04fd1060-8e79-4015-be67-243fad88fbb2" />

## After
<img width="744" height="673" alt="image" src="https://github.com/user-attachments/assets/6559cb35-94f7-48aa-acab-fa1b38619661" />

<img width="747" height="677" alt="image" src="https://github.com/user-attachments/assets/f62d783d-d696-4e24-8d55-9fe33837279e" />
