### PR TITLE
ci: use microsoft's playwright container

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,6 +35,9 @@ jobs:
         run: yarn test
   Vitest:
     runs-on: ubuntu-latest
+    container:
+      # Keep this image tag aligned with package.json's playwright version.
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -49,7 +52,5 @@ jobs:
         run: yarn
       - name: Build ReScript
         run: yarn build:res
-      - name: Install Playwright
-        run: yarn playwright install --with-deps
       - name: Vitest
         run: yarn ci:test


### PR DESCRIPTION
Installing the playwright browsers can take a while, so these shaves off around 40s from the Vitest CI job.