### PR TITLE
Update links for @as attribute in cheatsheet

### DIFF
--- a/markdown-pages/docs/manual/interop-cheatsheet.mdx
+++ b/markdown-pages/docs/manual/interop-cheatsheet.mdx
@@ -18,7 +18,7 @@ This is a glossary with examples. All the features are described by later pages.
 
 ### Attributes
 
-- `@as`: [here](./attribute.mdx#usage), [here](./bind-to-js-function.mdx#fixed-arguments), [here](./bind-to-js-function.mdx#constrain-arguments-better) and [here](./generate-converters-accessors.mdx#usage-3)
+- `@as`: [here](./variant.mdx#tagged-variants), [here](./attribute.mdx#usage), [here](./bind-to-js-function.mdx#fixed-arguments), [here](./bind-to-js-function.mdx#constrain-arguments-better) and [here](./generate-converters-accessors.mdx#usage-3)
 - [`@deriving`](./generate-converters-accessors.mdx#generate-functions--plain-values-for-variants)
 - [`@get`](./bind-to-js-object.mdx#bind-using-special-bs-getters--setters)
 - [`@get_index`](./bind-to-js-object.mdx#bind-using-special-bs-getters--setters)


### PR DESCRIPTION
Referencing the main explanation for the `@as` attribute in variants.