### PR TITLE
fix: avoid duplicate breadcrumbs

### DIFF
--- a/apps/docs/__tests__/Breadcrumbs_.test.res
+++ b/apps/docs/__tests__/Breadcrumbs_.test.res
@@ -1,6 +1,8 @@
 open ReactRouter
 open Vitest
 
+@get external textContent: WebAPI.DOMAPI.element => string = "textContent"
+
 let mockBreadcrumbs: list<Url.breadcrumb> = list{
   {Url.name: "Docs", href: "/docs/"},
   {Url.name: "Language Manual", href: "/docs/manual/introduction"},
@@ -10,11 +12,11 @@ test("breadcrumbs render path segments", async () => {
   await viewport(1440, 900)
 
   let screen = await render(
-    <BrowserRouter>
+    <MemoryRouter initialEntries=["/docs/manual/introduction"]>
       <div dataTestId="breadcrumbs-wrapper">
         <Breadcrumbs crumbs=mockBreadcrumbs />
       </div>
-    </BrowserRouter>,
+    </MemoryRouter>,
   )
 
   let docs = await screen->getByText("Docs")
@@ -37,11 +39,11 @@ test("breadcrumbs with deep path", async () => {
   }
 
   let screen = await render(
-    <BrowserRouter>
+    <MemoryRouter initialEntries=["/docs/manual/advanced"]>
       <div dataTestId="breadcrumbs-wrapper">
         <Breadcrumbs crumbs=deepBreadcrumbs />
       </div>
-    </BrowserRouter>,
+    </MemoryRouter>,
   )
 
   let docs = await screen->getByText("Docs")
@@ -55,4 +57,30 @@ test("breadcrumbs with deep path", async () => {
 
   let wrapper = await screen->getByTestId("breadcrumbs-wrapper")
   await element(wrapper)->toMatchScreenshot("sidebar-breadcrumbs-deep")
+})
+
+test("breadcrumbs do not repeat the current page crumb when it is already included", async () => {
+  await viewport(1440, 900)
+
+  let apiBreadcrumbs: list<Url.breadcrumb> = list{
+    {Url.name: "Docs", href: "/docs/manual/api"},
+    {Url.name: "API", href: "/docs/manual/api"},
+    {Url.name: "Stdlib", href: "/docs/manual/api/stdlib"},
+  }
+
+  let screen = await render(
+    <MemoryRouter initialEntries=["/docs/manual/api/stdlib"]>
+      <div dataTestId="breadcrumbs-wrapper">
+        <Breadcrumbs crumbs=apiBreadcrumbs />
+      </div>
+    </MemoryRouter>,
+  )
+
+  let _breadcrumbs = await screen->getByTestId("breadcrumbs")
+  let breadcrumbs = switch document->WebAPI.Document.querySelector("[data-testid='breadcrumbs']") {
+  | Value(breadcrumbs) => breadcrumbs
+  | Null => failwith("expected breadcrumbs")
+  }
+
+  expect(breadcrumbs->textContent)->toBe("Docs / API / Stdlib")
 })

--- a/apps/docs/e2e/Breadcrumbs.cy.res
+++ b/apps/docs/e2e/Breadcrumbs.cy.res
@@ -1,0 +1,32 @@
+open Cy
+
+let waitForPage = () => {
+  getByTestId("navbar-primary")->shouldBeVisible->ignore
+  getByTestId("navbar-tertiary")->shouldBeVisible->ignore
+  cyWindow()->its("document.readyState")->shouldWithValue("eq", "complete")->ignore
+}
+
+let expectBreadcrumbsText = text => {
+  getByTestId("breadcrumbs")
+  ->should("be.visible")
+  ->shouldWithValue("have.text", text)
+  ->ignore
+}
+
+describe("Breadcrumbs", () => {
+  beforeEach(() => {
+    viewport(1280, 720)
+  })
+
+  it("does not repeat the API root breadcrumb", () => {
+    visit("/docs/manual/api/stdlib/")
+    waitForPage()
+    expectBreadcrumbsText("Docs / API / Stdlib")
+  })
+
+  it("does not repeat nested API breadcrumbs", () => {
+    visit("/docs/manual/api/stdlib/arraybuffer/")
+    waitForPage()
+    expectBreadcrumbsText("Docs / API / Stdlib / Arraybuffer")
+  })
+})

--- a/apps/docs/src/components/Breadcrumbs.res
+++ b/apps/docs/src/components/Breadcrumbs.res
@@ -1,5 +1,14 @@
 module Link = ReactRouter.Link
 
+let normalizeName = name => name->String.trim->String.toLowerCase
+
+let endsWithCrumb = (~crumbs: list<Url.breadcrumb>, ~name) => {
+  switch crumbs->List.toArray->Array.last {
+  | Some(crumb) => crumb.name->normalizeName === name->normalizeName
+  | None => false
+  }
+}
+
 @react.component
 let make = (~crumbs: list<Url.breadcrumb>) => {
   let {pathname} = ReactRouter.useLocation()
@@ -16,15 +25,22 @@ let make = (~crumbs: list<Url.breadcrumb>) => {
     )
     ->Array.last
 
-  let crumbs = switch lastSegment {
+  let currentCrumb = switch lastSegment {
   | Some(lastSegment) =>
-    crumbs->List.concat(list{
-      {Url.name: lastSegment->String.capitalize, href: (pathname :> string)},
+    Some({
+      Url.name: lastSegment->String.capitalize,
+      href: (pathname :> string),
     })
-  | None => crumbs
+  | None => None
   }
 
-  <div className="w-full captions overflow-x-auto text-gray-60">
+  let crumbs = switch currentCrumb {
+  | Some(currentCrumb) if !endsWithCrumb(~crumbs, ~name=currentCrumb.name) =>
+    crumbs->List.concat(list{currentCrumb})
+  | Some(_) | None => crumbs
+  }
+
+  <div dataTestId="breadcrumbs" className="w-full captions overflow-x-auto text-gray-60">
     {List.mapWithIndex(crumbs, (crumb, i) => {
       let item = if i === List.length(crumbs) - 1 {
         <span key={Int.toString(i)}> {React.string(crumb.name)} </span>


### PR DESCRIPTION
## Context

API docs routes can pass breadcrumbs that already include the current page. `Breadcrumbs` was also deriving the current page from the URL and appending it unconditionally, which produced duplicates like `Docs / API / Stdlib / Stdlib` and `Docs / API / Stdlib / Arraybuffer / Arraybuffer`.

## Changes

- Skip appending the derived current crumb when the supplied breadcrumb list already ends with the same label.
- Add a stable `data-testid` for breadcrumb assertions.
- Add Vitest coverage for the component behavior.
- Add Cypress coverage for the affected API docs routes.

## Verification

- `yarn format`
- `yarn ci:format`
- `yarn build:res`
- `yarn vitest --run --browser.headless __tests__/Breadcrumbs_.test.jsx`
- `yarn build`
- `yarn workspace @rescript-lang/docs cypress run --browser electron --spec e2e/Breadcrumbs.cy.jsx`
- `git diff --cached --check`