### PR TITLE
claim llms.txt url for context7

### DIFF
--- a/apps/docs/public/llms/context7.json
+++ b/apps/docs/public/llms/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/llmstxt/rescript-lang_llms_txt",
+  "public_key": "pk_dEopRkFptH4ndnTyOuXEb"
+}


### PR DESCRIPTION
Claim https://context7.com/llmstxt/rescript-lang_llms_txt to have [rescript-lang.org/llms.txt](https://rescript-lang.org/llms.txt) marked as official.