### PR TITLE
[codex] fix legacy llms redirects

### DIFF
--- a/apps/docs/public/_redirects
+++ b/apps/docs/public/_redirects
@@ -8,6 +8,22 @@
 /llms/manual/llms.txt  /llms.txt  307
 /llms/manual/latest/llms.txt  /llms.txt  307
 /llms/manual/next/llms.txt  /llms.txt  307
+/llms/manual/v13.0.0/llms.txt  /llms/manual/v13/llms.txt  307
+/llms/manual/v13.0.0/llms-full.txt  /llms/manual/v13/llm-full.txt  307
+/llms/manual/v13.0.0/llms-small.txt  /llms/manual/v13/llm-small.txt  307
+/llms/manual/v13.0.0/*  /llms/manual/v13/:splat  307
+/llms/manual/v12.0.0/llms.txt  /llms/manual/v12/llms.txt  307
+/llms/manual/v12.0.0/llms-full.txt  /llms/manual/v12/llm-full.txt  307
+/llms/manual/v12.0.0/llms-small.txt  /llms/manual/v12/llm-small.txt  307
+/llms/manual/v12.0.0/*  /llms/manual/v12/:splat  307
+/llms/manual/v11/llms.txt  /llms/manual/v12/llms.txt  307
+/llms/manual/v11/llms-full.txt  /llms/manual/v12/llm-full.txt  307
+/llms/manual/v11/llms-small.txt  /llms/manual/v12/llm-small.txt  307
+/llms/manual/v11/*  /llms/manual/v12/:splat  307
+/llms/manual/v11.0.0/llms.txt  /llms/manual/v12/llms.txt  307
+/llms/manual/v11.0.0/llms-full.txt  /llms/manual/v12/llm-full.txt  307
+/llms/manual/v11.0.0/llms-small.txt  /llms/manual/v12/llm-small.txt  307
+/llms/manual/v11.0.0/*  /llms/manual/v12/:splat  307
 /llms/manual/latest/*  /llms/manual/:splat  307
 /llms/manual/next/*  /llms/manual/:splat  307
 

--- a/apps/docs/scripts/test-redirects.mjs
+++ b/apps/docs/scripts/test-redirects.mjs
@@ -30,6 +30,44 @@ let assertRedirect = (source, destination, status) => {
   return entry;
 };
 
+let assertManualLlmsVersionRedirects = (sourceVersion, destinationVersion) => {
+  const sourcePrefix = `/llms/manual/${sourceVersion}`;
+  const destinationPrefix = `/llms/manual/${destinationVersion}`;
+  const index = assertRedirect(
+    `${sourcePrefix}/llms.txt`,
+    `${destinationPrefix}/llms.txt`,
+    "307",
+  );
+  const full = assertRedirect(
+    `${sourcePrefix}/llms-full.txt`,
+    `${destinationPrefix}/llm-full.txt`,
+    "307",
+  );
+  const small = assertRedirect(
+    `${sourcePrefix}/llms-small.txt`,
+    `${destinationPrefix}/llm-small.txt`,
+    "307",
+  );
+  const wildcard = assertRedirect(
+    `${sourcePrefix}/*`,
+    `${destinationPrefix}/:splat`,
+    "307",
+  );
+
+  assert.ok(
+    index.index < wildcard.index,
+    `${sourcePrefix}/llms.txt must be listed before ${sourcePrefix}/*`,
+  );
+  assert.ok(
+    full.index < wildcard.index,
+    `${sourcePrefix}/llms-full.txt must be listed before ${sourcePrefix}/*`,
+  );
+  assert.ok(
+    small.index < wildcard.index,
+    `${sourcePrefix}/llms-small.txt must be listed before ${sourcePrefix}/*`,
+  );
+};
+
 assertRedirect("/llms/manual/llms.txt", "/llms.txt", "307");
 const latestAlias = assertRedirect(
   "/llms/manual/latest/llms.txt",
@@ -41,6 +79,10 @@ const nextAlias = assertRedirect(
   "/llms.txt",
   "307",
 );
+assertManualLlmsVersionRedirects("v13.0.0", "v13");
+assertManualLlmsVersionRedirects("v12.0.0", "v12");
+assertManualLlmsVersionRedirects("v11", "v12");
+assertManualLlmsVersionRedirects("v11.0.0", "v12");
 
 assert.ok(
   latestAlias.index < findEntry("/llms/manual/latest/*").index,


### PR DESCRIPTION
## Context

Some legacy manual LLM URLs used patch-versioned paths and plural `llms-full.txt` / `llms-small.txt` filenames. Those URLs were not covered by the existing Cloudflare `_redirects` aliases, so requests could miss the current major-version LLM files.

## Summary

- Add explicit redirects for `/llms/manual/v13.0.0/*` to `/llms/manual/v13/*`.
- Add explicit redirects for `/llms/manual/v12.0.0/*` to `/llms/manual/v12/*`.
- Redirect `/llms/manual/v11/*` and `/llms/manual/v11.0.0/*` to the current v12 LLM files.
- Extend redirect tests to assert exact file redirects and ordering before wildcard fallbacks.

## Validation

- `node apps/docs/scripts/test-redirects.mjs`
- `yarn test`
- `git diff --check`
- `yarn ci:format apps/docs/scripts/test-redirects.mjs`