### PR TITLE
[codex] Add focused manual LLM files

### DIFF
--- a/apps/docs/e2e/Navigation.cy.res
+++ b/apps/docs/e2e/Navigation.cy.res
@@ -15,15 +15,21 @@ let waitForHydration = () => {
 // re-query from the DOM root on each retry.
 
 let clickNavLink = (~testId, ~text) => {
-  get(`[data-testid="${testId}"] a:visible`)
-  ->containsChainable(text)
+  getByTestId(testId)
+  ->should("be.visible")
+  ->containsSelectorChainable("a", text)
+  ->scrollIntoView
+  ->should("be.visible")
   ->click
   ->ignore
 }
 
 let clickMobileNavLink = text => {
-  get(`[data-testid="mobile-nav"] a:visible`)
-  ->containsChainable(text)
+  getByTestId("mobile-nav")
+  ->should("be.visible")
+  ->containsSelectorChainable("a", text)
+  ->scrollIntoView
+  ->should("be.visible")
   ->click
   ->ignore
 }

--- a/apps/docs/markdown-pages/docs/manual/llms.mdx
+++ b/apps/docs/markdown-pages/docs/manual/llms.mdx
@@ -21,6 +21,8 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 - [/llms/manual/llm-small.txt](/llms/manual/llm-small.txt) - abridged current documentation without detailed examples.
 - [/llms/manual/language-overview/llm.txt](/llms/manual/language-overview/llm.txt) - focused documentation for ReScript syntax and core language features.
 - [/llms/manual/javascript-interop/llm.txt](/llms/manual/javascript-interop/llm.txt) - focused documentation for binding to JavaScript and TypeScript code.
+- [/llms/manual/build-system/llm.txt](/llms/manual/build-system/llm.txt) - focused documentation for build configuration, project structure, and build-tool integration.
+- [/llms/manual/getting-started/llm.txt](/llms/manual/getting-started/llm.txt) - focused documentation for installation, editor setup, migrations, and JavaScript onboarding.
 
 ## Package Documentation
 
@@ -37,8 +39,12 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 - [v13 pre-release abridged documentation](/llms/manual/v13/llm-small.txt) - abridged latest ReScript v13 pre-release documentation.
 - [v13 pre-release language overview](/llms/manual/v13/language-overview/llm.txt) - focused latest ReScript v13 pre-release language overview.
 - [v13 pre-release JavaScript interop](/llms/manual/v13/javascript-interop/llm.txt) - focused latest ReScript v13 pre-release JavaScript interop reference.
+- [v13 pre-release build system](/llms/manual/v13/build-system/llm.txt) - focused latest ReScript v13 pre-release build system reference.
+- [v13 pre-release getting started](/llms/manual/v13/getting-started/llm.txt) - focused latest ReScript v13 pre-release onboarding reference.
 - [v12 current LLMs index](/llms/manual/v12/llms.txt) - a list of the available files for the current ReScript v12 documentation.
 - [v12 current complete documentation](/llms/manual/v12/llm-full.txt) - complete current ReScript v12 documentation.
 - [v12 current abridged documentation](/llms/manual/v12/llm-small.txt) - abridged current ReScript v12 documentation.
 - [v12 current language overview](/llms/manual/v12/language-overview/llm.txt) - focused current ReScript v12 language overview.
 - [v12 current JavaScript interop](/llms/manual/v12/javascript-interop/llm.txt) - focused current ReScript v12 JavaScript interop reference.
+- [v12 current build system](/llms/manual/v12/build-system/llm.txt) - focused current ReScript v12 build system reference.
+- [v12 current getting started](/llms/manual/v12/getting-started/llm.txt) - focused current ReScript v12 onboarding reference.

--- a/apps/docs/markdown-pages/docs/manual/llms.mdx
+++ b/apps/docs/markdown-pages/docs/manual/llms.mdx
@@ -19,6 +19,8 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 - [/llms.txt](/llms.txt) - a list of the available files for the current ReScript language manual.
 - [/llms/manual/llm-full.txt](/llms/manual/llm-full.txt) - complete current documentation for the ReScript language.
 - [/llms/manual/llm-small.txt](/llms/manual/llm-small.txt) - abridged current documentation without detailed examples.
+- [/llms/manual/language-overview/llm.txt](/llms/manual/language-overview/llm.txt) - focused documentation for ReScript syntax and core language features.
+- [/llms/manual/javascript-interop/llm.txt](/llms/manual/javascript-interop/llm.txt) - focused documentation for binding to JavaScript and TypeScript code.
 
 ## Package Documentation
 
@@ -33,6 +35,10 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 - [v13 pre-release LLMs index](/llms/manual/v13/llms.txt) - a list of the available files for the latest ReScript v13 pre-release documentation.
 - [v13 pre-release complete documentation](/llms/manual/v13/llm-full.txt) - complete latest ReScript v13 pre-release documentation.
 - [v13 pre-release abridged documentation](/llms/manual/v13/llm-small.txt) - abridged latest ReScript v13 pre-release documentation.
+- [v13 pre-release language overview](/llms/manual/v13/language-overview/llm.txt) - focused latest ReScript v13 pre-release language overview.
+- [v13 pre-release JavaScript interop](/llms/manual/v13/javascript-interop/llm.txt) - focused latest ReScript v13 pre-release JavaScript interop reference.
 - [v12 current LLMs index](/llms/manual/v12/llms.txt) - a list of the available files for the current ReScript v12 documentation.
 - [v12 current complete documentation](/llms/manual/v12/llm-full.txt) - complete current ReScript v12 documentation.
 - [v12 current abridged documentation](/llms/manual/v12/llm-small.txt) - abridged current ReScript v12 documentation.
+- [v12 current language overview](/llms/manual/v12/language-overview/llm.txt) - focused current ReScript v12 language overview.
+- [v12 current JavaScript interop](/llms/manual/v12/javascript-interop/llm.txt) - focused current ReScript v12 JavaScript interop reference.

--- a/apps/docs/markdown-pages/docs/manual/llms.mdx
+++ b/apps/docs/markdown-pages/docs/manual/llms.mdx
@@ -10,15 +10,11 @@ order: 4
 
 We adhere to the [llms.txt convention](https://llmstxt.org/) to make documentation accessible to large language models and their applications.
 
-This ReScript manual major version: `v12 (current version)`.
+## Files
 
-The root `/llms.txt` file is the default entry point and always describes the current stable manual. Use the files under `/llms/manual/v13/` (pre-release version) or `/llms/manual/v12/` (current version) when you want an explicit major-version path. These major-version paths use the latest generated documentation for that major version and avoid full patch numbers in the URL.
-
-## Default Current Files
-
-- [/llms.txt](/llms.txt) - a list of the available files for the current ReScript language manual.
-- [/llms/manual/llm-full.txt](/llms/manual/llm-full.txt) - complete current documentation for the ReScript language.
-- [/llms/manual/llm-small.txt](/llms/manual/llm-small.txt) - abridged current documentation without detailed examples.
+- [/llms.txt](/llms.txt) - a list of the available files for the ReScript language manual.
+- [/llms/manual/llm-full.txt](/llms/manual/llm-full.txt) - complete documentation for the ReScript language.
+- [/llms/manual/llm-small.txt](/llms/manual/llm-small.txt) - abridged documentation without detailed examples.
 - [/llms/manual/language-overview/llm.txt](/llms/manual/language-overview/llm.txt) - focused documentation for ReScript syntax and core language features.
 - [/llms/manual/javascript-interop/llm.txt](/llms/manual/javascript-interop/llm.txt) - focused documentation for binding to JavaScript and TypeScript code.
 - [/llms/manual/build-system/llm.txt](/llms/manual/build-system/llm.txt) - focused documentation for build configuration, project structure, and build-tool integration.
@@ -32,7 +28,7 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 
 - The content is automatically generated from the same source as the official documentation for the specific version.
 
-## Major Version Files
+## Versioned Files
 
 - [v13 pre-release LLMs index](/llms/manual/v13/llms.txt) - a list of the available files for the latest ReScript v13 pre-release documentation.
 - [v13 pre-release complete documentation](/llms/manual/v13/llm-full.txt) - complete latest ReScript v13 pre-release documentation.
@@ -41,10 +37,10 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 - [v13 pre-release JavaScript interop](/llms/manual/v13/javascript-interop/llm.txt) - focused latest ReScript v13 pre-release JavaScript interop reference.
 - [v13 pre-release build system](/llms/manual/v13/build-system/llm.txt) - focused latest ReScript v13 pre-release build system reference.
 - [v13 pre-release getting started](/llms/manual/v13/getting-started/llm.txt) - focused latest ReScript v13 pre-release onboarding reference.
-- [v12 current LLMs index](/llms/manual/v12/llms.txt) - a list of the available files for the current ReScript v12 documentation.
-- [v12 current complete documentation](/llms/manual/v12/llm-full.txt) - complete current ReScript v12 documentation.
-- [v12 current abridged documentation](/llms/manual/v12/llm-small.txt) - abridged current ReScript v12 documentation.
-- [v12 current language overview](/llms/manual/v12/language-overview/llm.txt) - focused current ReScript v12 language overview.
-- [v12 current JavaScript interop](/llms/manual/v12/javascript-interop/llm.txt) - focused current ReScript v12 JavaScript interop reference.
-- [v12 current build system](/llms/manual/v12/build-system/llm.txt) - focused current ReScript v12 build system reference.
-- [v12 current getting started](/llms/manual/v12/getting-started/llm.txt) - focused current ReScript v12 onboarding reference.
+- [v12 LLMs index](/llms/manual/v12/llms.txt) - a list of the available files for ReScript v12 documentation.
+- [v12 complete documentation](/llms/manual/v12/llm-full.txt) - complete ReScript v12 documentation.
+- [v12 abridged documentation](/llms/manual/v12/llm-small.txt) - abridged ReScript v12 documentation.
+- [v12 language overview](/llms/manual/v12/language-overview/llm.txt) - focused ReScript v12 language overview.
+- [v12 JavaScript interop](/llms/manual/v12/javascript-interop/llm.txt) - focused ReScript v12 JavaScript interop reference.
+- [v12 build system](/llms/manual/v12/build-system/llm.txt) - focused ReScript v12 build system reference.
+- [v12 getting started](/llms/manual/v12/getting-started/llm.txt) - focused ReScript v12 onboarding reference.

--- a/apps/docs/markdown-pages/docs/manual/llms.mdx
+++ b/apps/docs/markdown-pages/docs/manual/llms.mdx
@@ -27,20 +27,3 @@ We adhere to the [llms.txt convention](https://llmstxt.org/) to make documentati
 ## Notes
 
 - The content is automatically generated from the same source as the official documentation for the specific version.
-
-## Versioned Files
-
-- [v13 pre-release LLMs index](/llms/manual/v13/llms.txt) - a list of the available files for the latest ReScript v13 pre-release documentation.
-- [v13 pre-release complete documentation](/llms/manual/v13/llm-full.txt) - complete latest ReScript v13 pre-release documentation.
-- [v13 pre-release abridged documentation](/llms/manual/v13/llm-small.txt) - abridged latest ReScript v13 pre-release documentation.
-- [v13 pre-release language overview](/llms/manual/v13/language-overview/llm.txt) - focused latest ReScript v13 pre-release language overview.
-- [v13 pre-release JavaScript interop](/llms/manual/v13/javascript-interop/llm.txt) - focused latest ReScript v13 pre-release JavaScript interop reference.
-- [v13 pre-release build system](/llms/manual/v13/build-system/llm.txt) - focused latest ReScript v13 pre-release build system reference.
-- [v13 pre-release getting started](/llms/manual/v13/getting-started/llm.txt) - focused latest ReScript v13 pre-release onboarding reference.
-- [v12 LLMs index](/llms/manual/v12/llms.txt) - a list of the available files for ReScript v12 documentation.
-- [v12 complete documentation](/llms/manual/v12/llm-full.txt) - complete ReScript v12 documentation.
-- [v12 abridged documentation](/llms/manual/v12/llm-small.txt) - abridged ReScript v12 documentation.
-- [v12 language overview](/llms/manual/v12/language-overview/llm.txt) - focused ReScript v12 language overview.
-- [v12 JavaScript interop](/llms/manual/v12/javascript-interop/llm.txt) - focused ReScript v12 JavaScript interop reference.
-- [v12 build system](/llms/manual/v12/build-system/llm.txt) - focused ReScript v12 build system reference.
-- [v12 getting started](/llms/manual/v12/getting-started/llm.txt) - focused ReScript v12 onboarding reference.

--- a/apps/docs/markdown-pages/docs/react/llms.mdx
+++ b/apps/docs/markdown-pages/docs/react/llms.mdx
@@ -15,12 +15,6 @@ We adhere to the [llms.txt convention](https://llmstxt.org/) to make documentati
 - [/llms/react/llm-full.txt](/llms/react/llm-full.txt) - complete documentation for ReScript React.
 - [/llms/react/llm-small.txt](/llms/react/llm-small.txt) - abridged documentation without detailed examples.
 
-## Versioned Files
-
-- [/llms/react/v0.14.2/llms.txt](/llms/react/v0.14.2/llms.txt) - a list of the available files for ReScript React `v0.14.2`.
-- [/llms/react/v0.14.2/llm-full.txt](/llms/react/v0.14.2/llm-full.txt) - complete documentation for ReScript React `v0.14.2`.
-- [/llms/react/v0.14.2/llm-small.txt](/llms/react/v0.14.2/llm-small.txt) - abridged documentation for ReScript React `v0.14.2`.
-
 ## Language Documentation
 
 - [/llms.txt](/llms.txt) - the LLM documentation for ReScript.

--- a/apps/docs/markdown-pages/docs/react/llms.mdx
+++ b/apps/docs/markdown-pages/docs/react/llms.mdx
@@ -9,17 +9,11 @@ section: "Overview"
 
 We adhere to the [llms.txt convention](https://llmstxt.org/) to make documentation accessible to large language models and their applications.
 
-Current ReScript React documentation version: `v0.14.2`.
-ReScript React package version: `v0.14.2`.
-React version: `v19.2.4`.
+## Files
 
-The unversioned files under `/llms/react/` are the default entry points and always describe the current ReScript React docs. Use the versioned files under `/llms/react/v0.14.2/` when you want a stable path for this ReScript React documentation version.
-
-## Default Current Files
-
-- [/llms/react/llms.txt](/llms/react/llms.txt) - a list of the available files for the current ReScript React docs.
-- [/llms/react/llm-full.txt](/llms/react/llm-full.txt) - complete current documentation for ReScript React.
-- [/llms/react/llm-small.txt](/llms/react/llm-small.txt) - abridged current documentation without detailed examples.
+- [/llms/react/llms.txt](/llms/react/llms.txt) - a list of the available files for ReScript React docs.
+- [/llms/react/llm-full.txt](/llms/react/llm-full.txt) - complete documentation for ReScript React.
+- [/llms/react/llm-small.txt](/llms/react/llm-small.txt) - abridged documentation without detailed examples.
 
 ## Versioned Files
 

--- a/apps/docs/public/llms/manual/template.mdx
+++ b/apps/docs/public/llms/manual/template.mdx
@@ -10,15 +10,11 @@ order: 4
 
 We adhere to the [llms.txt convention](https://llmstxt.org/) to make documentation accessible to large language models and their applications.
 
-This ReScript manual major version: `<MANUAL_VERSION_LABEL>`.
+## Files
 
-The root `/llms.txt` file is the default entry point and always describes the current stable manual. Use the files under `/llms/manual/v13/` (pre-release version) or `/llms/manual/v12/` (current version) when you want an explicit major-version path. These major-version paths use the latest generated documentation for that major version and avoid full patch numbers in the URL.
-
-## Default Current Files
-
-- [/llms.txt](/llms.txt) - a list of the available files for the current ReScript language manual.
-- [/llms/manual/llm-full.txt](/llms/manual/llm-full.txt) - complete current documentation for the ReScript language.
-- [/llms/manual/llm-small.txt](/llms/manual/llm-small.txt) - abridged current documentation without detailed examples.
+- [/llms.txt](/llms.txt) - a list of the available files for the ReScript language manual.
+- [/llms/manual/llm-full.txt](/llms/manual/llm-full.txt) - complete documentation for the ReScript language.
+- [/llms/manual/llm-small.txt](/llms/manual/llm-small.txt) - abridged documentation without detailed examples.
 - [/llms/manual/language-overview/llm.txt](/llms/manual/language-overview/llm.txt) - focused documentation for ReScript syntax and core language features.
 - [/llms/manual/javascript-interop/llm.txt](/llms/manual/javascript-interop/llm.txt) - focused documentation for binding to JavaScript and TypeScript code.
 - [/llms/manual/build-system/llm.txt](/llms/manual/build-system/llm.txt) - focused documentation for build configuration, project structure, and build-tool integration.
@@ -32,7 +28,7 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 
 - The content is automatically generated from the same source as the official documentation for the specific version.
 
-## Major Version Files
+## Versioned Files
 
 - [v13 pre-release LLMs index](/llms/manual/v13/llms.txt) - a list of the available files for the latest ReScript v13 pre-release documentation.
 - [v13 pre-release complete documentation](/llms/manual/v13/llm-full.txt) - complete latest ReScript v13 pre-release documentation.
@@ -41,10 +37,10 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 - [v13 pre-release JavaScript interop](/llms/manual/v13/javascript-interop/llm.txt) - focused latest ReScript v13 pre-release JavaScript interop reference.
 - [v13 pre-release build system](/llms/manual/v13/build-system/llm.txt) - focused latest ReScript v13 pre-release build system reference.
 - [v13 pre-release getting started](/llms/manual/v13/getting-started/llm.txt) - focused latest ReScript v13 pre-release onboarding reference.
-- [v12 current LLMs index](/llms/manual/v12/llms.txt) - a list of the available files for the current ReScript v12 documentation.
-- [v12 current complete documentation](/llms/manual/v12/llm-full.txt) - complete current ReScript v12 documentation.
-- [v12 current abridged documentation](/llms/manual/v12/llm-small.txt) - abridged current ReScript v12 documentation.
-- [v12 current language overview](/llms/manual/v12/language-overview/llm.txt) - focused current ReScript v12 language overview.
-- [v12 current JavaScript interop](/llms/manual/v12/javascript-interop/llm.txt) - focused current ReScript v12 JavaScript interop reference.
-- [v12 current build system](/llms/manual/v12/build-system/llm.txt) - focused current ReScript v12 build system reference.
-- [v12 current getting started](/llms/manual/v12/getting-started/llm.txt) - focused current ReScript v12 onboarding reference.
+- [v12 LLMs index](/llms/manual/v12/llms.txt) - a list of the available files for ReScript v12 documentation.
+- [v12 complete documentation](/llms/manual/v12/llm-full.txt) - complete ReScript v12 documentation.
+- [v12 abridged documentation](/llms/manual/v12/llm-small.txt) - abridged ReScript v12 documentation.
+- [v12 language overview](/llms/manual/v12/language-overview/llm.txt) - focused ReScript v12 language overview.
+- [v12 JavaScript interop](/llms/manual/v12/javascript-interop/llm.txt) - focused ReScript v12 JavaScript interop reference.
+- [v12 build system](/llms/manual/v12/build-system/llm.txt) - focused ReScript v12 build system reference.
+- [v12 getting started](/llms/manual/v12/getting-started/llm.txt) - focused ReScript v12 onboarding reference.

--- a/apps/docs/public/llms/manual/template.mdx
+++ b/apps/docs/public/llms/manual/template.mdx
@@ -21,6 +21,8 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 - [/llms/manual/llm-small.txt](/llms/manual/llm-small.txt) - abridged current documentation without detailed examples.
 - [/llms/manual/language-overview/llm.txt](/llms/manual/language-overview/llm.txt) - focused documentation for ReScript syntax and core language features.
 - [/llms/manual/javascript-interop/llm.txt](/llms/manual/javascript-interop/llm.txt) - focused documentation for binding to JavaScript and TypeScript code.
+- [/llms/manual/build-system/llm.txt](/llms/manual/build-system/llm.txt) - focused documentation for build configuration, project structure, and build-tool integration.
+- [/llms/manual/getting-started/llm.txt](/llms/manual/getting-started/llm.txt) - focused documentation for installation, editor setup, migrations, and JavaScript onboarding.
 
 ## Package Documentation
 
@@ -37,8 +39,12 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 - [v13 pre-release abridged documentation](/llms/manual/v13/llm-small.txt) - abridged latest ReScript v13 pre-release documentation.
 - [v13 pre-release language overview](/llms/manual/v13/language-overview/llm.txt) - focused latest ReScript v13 pre-release language overview.
 - [v13 pre-release JavaScript interop](/llms/manual/v13/javascript-interop/llm.txt) - focused latest ReScript v13 pre-release JavaScript interop reference.
+- [v13 pre-release build system](/llms/manual/v13/build-system/llm.txt) - focused latest ReScript v13 pre-release build system reference.
+- [v13 pre-release getting started](/llms/manual/v13/getting-started/llm.txt) - focused latest ReScript v13 pre-release onboarding reference.
 - [v12 current LLMs index](/llms/manual/v12/llms.txt) - a list of the available files for the current ReScript v12 documentation.
 - [v12 current complete documentation](/llms/manual/v12/llm-full.txt) - complete current ReScript v12 documentation.
 - [v12 current abridged documentation](/llms/manual/v12/llm-small.txt) - abridged current ReScript v12 documentation.
 - [v12 current language overview](/llms/manual/v12/language-overview/llm.txt) - focused current ReScript v12 language overview.
 - [v12 current JavaScript interop](/llms/manual/v12/javascript-interop/llm.txt) - focused current ReScript v12 JavaScript interop reference.
+- [v12 current build system](/llms/manual/v12/build-system/llm.txt) - focused current ReScript v12 build system reference.
+- [v12 current getting started](/llms/manual/v12/getting-started/llm.txt) - focused current ReScript v12 onboarding reference.

--- a/apps/docs/public/llms/manual/template.mdx
+++ b/apps/docs/public/llms/manual/template.mdx
@@ -19,6 +19,8 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 - [/llms.txt](/llms.txt) - a list of the available files for the current ReScript language manual.
 - [/llms/manual/llm-full.txt](/llms/manual/llm-full.txt) - complete current documentation for the ReScript language.
 - [/llms/manual/llm-small.txt](/llms/manual/llm-small.txt) - abridged current documentation without detailed examples.
+- [/llms/manual/language-overview/llm.txt](/llms/manual/language-overview/llm.txt) - focused documentation for ReScript syntax and core language features.
+- [/llms/manual/javascript-interop/llm.txt](/llms/manual/javascript-interop/llm.txt) - focused documentation for binding to JavaScript and TypeScript code.
 
 ## Package Documentation
 
@@ -33,6 +35,10 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 - [v13 pre-release LLMs index](/llms/manual/v13/llms.txt) - a list of the available files for the latest ReScript v13 pre-release documentation.
 - [v13 pre-release complete documentation](/llms/manual/v13/llm-full.txt) - complete latest ReScript v13 pre-release documentation.
 - [v13 pre-release abridged documentation](/llms/manual/v13/llm-small.txt) - abridged latest ReScript v13 pre-release documentation.
+- [v13 pre-release language overview](/llms/manual/v13/language-overview/llm.txt) - focused latest ReScript v13 pre-release language overview.
+- [v13 pre-release JavaScript interop](/llms/manual/v13/javascript-interop/llm.txt) - focused latest ReScript v13 pre-release JavaScript interop reference.
 - [v12 current LLMs index](/llms/manual/v12/llms.txt) - a list of the available files for the current ReScript v12 documentation.
 - [v12 current complete documentation](/llms/manual/v12/llm-full.txt) - complete current ReScript v12 documentation.
 - [v12 current abridged documentation](/llms/manual/v12/llm-small.txt) - abridged current ReScript v12 documentation.
+- [v12 current language overview](/llms/manual/v12/language-overview/llm.txt) - focused current ReScript v12 language overview.
+- [v12 current JavaScript interop](/llms/manual/v12/javascript-interop/llm.txt) - focused current ReScript v12 JavaScript interop reference.

--- a/apps/docs/public/llms/manual/template.mdx
+++ b/apps/docs/public/llms/manual/template.mdx
@@ -27,20 +27,3 @@ We adhere to the [llms.txt convention](https://llmstxt.org/) to make documentati
 ## Notes
 
 - The content is automatically generated from the same source as the official documentation for the specific version.
-
-## Versioned Files
-
-- [v13 pre-release LLMs index](/llms/manual/v13/llms.txt) - a list of the available files for the latest ReScript v13 pre-release documentation.
-- [v13 pre-release complete documentation](/llms/manual/v13/llm-full.txt) - complete latest ReScript v13 pre-release documentation.
-- [v13 pre-release abridged documentation](/llms/manual/v13/llm-small.txt) - abridged latest ReScript v13 pre-release documentation.
-- [v13 pre-release language overview](/llms/manual/v13/language-overview/llm.txt) - focused latest ReScript v13 pre-release language overview.
-- [v13 pre-release JavaScript interop](/llms/manual/v13/javascript-interop/llm.txt) - focused latest ReScript v13 pre-release JavaScript interop reference.
-- [v13 pre-release build system](/llms/manual/v13/build-system/llm.txt) - focused latest ReScript v13 pre-release build system reference.
-- [v13 pre-release getting started](/llms/manual/v13/getting-started/llm.txt) - focused latest ReScript v13 pre-release onboarding reference.
-- [v12 LLMs index](/llms/manual/v12/llms.txt) - a list of the available files for ReScript v12 documentation.
-- [v12 complete documentation](/llms/manual/v12/llm-full.txt) - complete ReScript v12 documentation.
-- [v12 abridged documentation](/llms/manual/v12/llm-small.txt) - abridged ReScript v12 documentation.
-- [v12 language overview](/llms/manual/v12/language-overview/llm.txt) - focused ReScript v12 language overview.
-- [v12 JavaScript interop](/llms/manual/v12/javascript-interop/llm.txt) - focused ReScript v12 JavaScript interop reference.
-- [v12 build system](/llms/manual/v12/build-system/llm.txt) - focused ReScript v12 build system reference.
-- [v12 getting started](/llms/manual/v12/getting-started/llm.txt) - focused ReScript v12 onboarding reference.

--- a/apps/docs/public/llms/manual/template.txt
+++ b/apps/docs/public/llms/manual/template.txt
@@ -15,6 +15,8 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 - [Abridged current documentation](https://rescript-lang.org/llms/manual/llm-small.txt): A minimal current version of the ReScript documentation, with the essential content for quick reference
 - [Language overview](https://rescript-lang.org/llms/manual/language-overview/llm.txt): Focused documentation for ReScript syntax and core language features
 - [JavaScript interop](https://rescript-lang.org/llms/manual/javascript-interop/llm.txt): Focused documentation for binding to JavaScript and TypeScript code
+- [Build system](https://rescript-lang.org/llms/manual/build-system/llm.txt): Focused documentation for build configuration, project structure, and build-tool integration
+- [Getting started](https://rescript-lang.org/llms/manual/getting-started/llm.txt): Focused documentation for installation, editor setup, migrations, and JavaScript onboarding
 
 ## Individual Package Documentation
 

--- a/apps/docs/public/llms/manual/template.txt
+++ b/apps/docs/public/llms/manual/template.txt
@@ -13,6 +13,8 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 - [LLMs index](https://rescript-lang.org/llms.txt): This file
 - [Complete current documentation](https://rescript-lang.org/llms/manual/llm-full.txt): The complete current ReScript documentation including all examples and additional content
 - [Abridged current documentation](https://rescript-lang.org/llms/manual/llm-small.txt): A minimal current version of the ReScript documentation, with the essential content for quick reference
+- [Language overview](https://rescript-lang.org/llms/manual/language-overview/llm.txt): Focused documentation for ReScript syntax and core language features
+- [JavaScript interop](https://rescript-lang.org/llms/manual/javascript-interop/llm.txt): Focused documentation for binding to JavaScript and TypeScript code
 
 ## Individual Package Documentation
 

--- a/apps/docs/public/llms/manual/template.txt
+++ b/apps/docs/public/llms/manual/template.txt
@@ -6,7 +6,7 @@
 
 This ReScript manual major version: <MANUAL_VERSION_LABEL>.
 
-The root `/llms.txt` file is the default entry point and always describes the current stable manual. Use the files under `/llms/manual/v13/` (pre-release version) or `/llms/manual/v12/` (current version) when you want an explicit major-version path. These major-version paths use the latest generated documentation for that major version and avoid full patch numbers in the URL.
+The root `/llms.txt` file is the default entry point and always describes the current stable manual.
 
 ### Default Current Files
 
@@ -28,7 +28,3 @@ The root `/llms.txt` file is the default entry point and always describes the cu
 - The complete documentation includes all content from the official documentation
 - Package-specific documentation files contain only the content relevant to that package
 - The content is automatically generated from the same source as the official documentation for the specific version
-
-### Major Version Files
-
-<MANUAL_VERSION_LINKS>

--- a/apps/docs/public/llms/manual/template.txt
+++ b/apps/docs/public/llms/manual/template.txt
@@ -2,23 +2,17 @@
 
 > ReScript is a robustly typed language that compiles to efficient and human-readable JavaScript. It comes with a lightning fast compiler toolchain that scales to any codebase size.
 
-## Documentation Sets
-
-This ReScript manual major version: <MANUAL_VERSION_LABEL>.
-
-The root `/llms.txt` file is the default entry point and always describes the current stable manual.
-
-### Default Current Files
+## Files
 
 - [LLMs index](https://rescript-lang.org/llms.txt): This file
-- [Complete current documentation](https://rescript-lang.org/llms/manual/llm-full.txt): The complete current ReScript documentation including all examples and additional content
-- [Abridged current documentation](https://rescript-lang.org/llms/manual/llm-small.txt): A minimal current version of the ReScript documentation, with the essential content for quick reference
+- [Complete documentation](https://rescript-lang.org/llms/manual/llm-full.txt): The complete ReScript documentation including all examples and additional content
+- [Abridged documentation](https://rescript-lang.org/llms/manual/llm-small.txt): A minimal ReScript documentation file with the essential content for quick reference
 - [Language overview](https://rescript-lang.org/llms/manual/language-overview/llm.txt): Focused documentation for ReScript syntax and core language features
 - [JavaScript interop](https://rescript-lang.org/llms/manual/javascript-interop/llm.txt): Focused documentation for binding to JavaScript and TypeScript code
 - [Build system](https://rescript-lang.org/llms/manual/build-system/llm.txt): Focused documentation for build configuration, project structure, and build-tool integration
 - [Getting started](https://rescript-lang.org/llms/manual/getting-started/llm.txt): Focused documentation for installation, editor setup, migrations, and JavaScript onboarding
 
-## Individual Package Documentation
+## Package Documentation
 
 - [ReScript React documentation](https://rescript-lang.org/llms/react/llms.txt): This is the developer documentation for ReScript React.
 

--- a/apps/docs/public/llms/react/template.mdx
+++ b/apps/docs/public/llms/react/template.mdx
@@ -15,12 +15,6 @@ We adhere to the [llms.txt convention](https://llmstxt.org/) to make documentati
 - [/llms/react/llm-full.txt](/llms/react/llm-full.txt) - complete documentation for ReScript React.
 - [/llms/react/llm-small.txt](/llms/react/llm-small.txt) - abridged documentation without detailed examples.
 
-## Versioned Files
-
-- [/llms/react/<VERSION>/llms.txt](/llms/react/<VERSION>/llms.txt) - a list of the available files for ReScript React `<VERSION>`.
-- [/llms/react/<VERSION>/llm-full.txt](/llms/react/<VERSION>/llm-full.txt) - complete documentation for ReScript React `<VERSION>`.
-- [/llms/react/<VERSION>/llm-small.txt](/llms/react/<VERSION>/llm-small.txt) - abridged documentation for ReScript React `<VERSION>`.
-
 ## Language Documentation
 
 - [/llms.txt](/llms.txt) - the LLM documentation for ReScript.

--- a/apps/docs/public/llms/react/template.mdx
+++ b/apps/docs/public/llms/react/template.mdx
@@ -9,17 +9,11 @@ section: "Overview"
 
 We adhere to the [llms.txt convention](https://llmstxt.org/) to make documentation accessible to large language models and their applications.
 
-Current ReScript React documentation version: `<VERSION>`.
-ReScript React package version: `<RESCRIPT_REACT_VERSION>`.
-React version: `<REACT_VERSION>`.
+## Files
 
-The unversioned files under `/llms/react/` are the default entry points and always describe the current ReScript React docs. Use the versioned files under `/llms/react/<VERSION>/` when you want a stable path for this ReScript React documentation version.
-
-## Default Current Files
-
-- [/llms/react/llms.txt](/llms/react/llms.txt) - a list of the available files for the current ReScript React docs.
-- [/llms/react/llm-full.txt](/llms/react/llm-full.txt) - complete current documentation for ReScript React.
-- [/llms/react/llm-small.txt](/llms/react/llm-small.txt) - abridged current documentation without detailed examples.
+- [/llms/react/llms.txt](/llms/react/llms.txt) - a list of the available files for ReScript React docs.
+- [/llms/react/llm-full.txt](/llms/react/llm-full.txt) - complete documentation for ReScript React.
+- [/llms/react/llm-small.txt](/llms/react/llm-small.txt) - abridged documentation without detailed examples.
 
 ## Versioned Files
 

--- a/apps/docs/public/llms/react/template.txt
+++ b/apps/docs/public/llms/react/template.txt
@@ -2,19 +2,11 @@
 
 > ReScript React is a strongly typed interface for React, designed to integrate seamlessly with modern React (>= v18.0) while compiling to idiomatic JavaScript, enabling robust and scalable React applications.
 
-## ReScript React Documentation
-
-Current ReScript React documentation version: <VERSION>.
-ReScript React package version: <RESCRIPT_REACT_VERSION>.
-React version: <REACT_VERSION>.
-
-The unversioned files under `/llms/react/` are the default entry points and always describe the current ReScript React docs.
-
-### Default Current Files
+## Files
 
 - [LLMs index](https://rescript-lang.org/llms/react/llms.txt): This file
-- [Complete current documentation](https://rescript-lang.org/llms/react/llm-full.txt): The complete current ReScript React documentation including all examples and additional content
-- [Abridged current documentation](https://rescript-lang.org/llms/react/llm-small.txt): A minimal current version of the ReScript React documentation, with the essential content for quick reference
+- [Complete documentation](https://rescript-lang.org/llms/react/llm-full.txt): The complete ReScript React documentation including all examples and additional content
+- [Abridged documentation](https://rescript-lang.org/llms/react/llm-small.txt): A minimal ReScript React documentation file with the essential content for quick reference
 
 ## Language Documentation
 

--- a/apps/docs/public/llms/react/template.txt
+++ b/apps/docs/public/llms/react/template.txt
@@ -8,19 +8,13 @@ Current ReScript React documentation version: <VERSION>.
 ReScript React package version: <RESCRIPT_REACT_VERSION>.
 React version: <REACT_VERSION>.
 
-The unversioned files under `/llms/react/` are the default entry points and always describe the current ReScript React docs. Use the versioned files under `/llms/react/<VERSION>/` when you want a stable path for this ReScript React documentation version.
+The unversioned files under `/llms/react/` are the default entry points and always describe the current ReScript React docs.
 
 ### Default Current Files
 
 - [LLMs index](https://rescript-lang.org/llms/react/llms.txt): This file
 - [Complete current documentation](https://rescript-lang.org/llms/react/llm-full.txt): The complete current ReScript React documentation including all examples and additional content
 - [Abridged current documentation](https://rescript-lang.org/llms/react/llm-small.txt): A minimal current version of the ReScript React documentation, with the essential content for quick reference
-
-### Versioned Files
-
-- [<VERSION> LLMs index](https://rescript-lang.org/llms/react/<VERSION>/llms.txt): This file for ReScript React <VERSION>
-- [<VERSION> complete documentation](https://rescript-lang.org/llms/react/<VERSION>/llm-full.txt): The complete ReScript React <VERSION> documentation including all examples and additional content
-- [<VERSION> abridged documentation](https://rescript-lang.org/llms/react/<VERSION>/llm-small.txt): A minimal ReScript React <VERSION> reference with the essential content
 
 ## Language Documentation
 

--- a/apps/docs/scripts/__tests__/generate-llms.test.mjs
+++ b/apps/docs/scripts/__tests__/generate-llms.test.mjs
@@ -25,6 +25,8 @@ let makeWorkspace = () => {
     "markdown-pages/docs/manual/introduction.mdx",
     `---
 title: "Introduction"
+section: "Overview"
+order: 1
 ---
 
 # Manual Introduction
@@ -67,6 +69,21 @@ JavaScript interop content.
 
   writeFile(
     root,
+    "markdown-pages/docs/manual/build-overview.mdx",
+    `---
+title: "Build Overview"
+section: "Build System"
+order: 1
+---
+
+# Build Overview
+
+Build system content.
+`,
+  );
+
+  writeFile(
+    root,
     "markdown-pages/docs/react/introduction.mdx",
     `---
 title: "React Introduction"
@@ -88,6 +105,8 @@ Version label: <MANUAL_VERSION_LABEL>
 - [Abridged documentation](https://rescript-lang.org/llms/manual/<VERSION>/llm-small.txt)
 - [Language overview](https://rescript-lang.org/llms/manual/language-overview/llm.txt)
 - [JavaScript interop](https://rescript-lang.org/llms/manual/javascript-interop/llm.txt)
+- [Build system](https://rescript-lang.org/llms/manual/build-system/llm.txt)
+- [Getting started](https://rescript-lang.org/llms/manual/getting-started/llm.txt)
 <MANUAL_VERSION_LINKS>
 `,
   );
@@ -102,12 +121,20 @@ Version label: <MANUAL_VERSION_LABEL>
   writeFile(
     root,
     "public/llms/manual/template.mdx",
-    `# Manual LLMs
+    `---
+title: "LLMs"
+section: "Overview"
+order: 4
+---
+
+# Manual LLMs
 
 - [/llms/manual/<VERSION>/llm-full.txt](/llms/manual/<VERSION>/llm-full.txt)
 - [/llms/manual/<VERSION>/llm-small.txt](/llms/manual/<VERSION>/llm-small.txt)
 - [/llms/manual/language-overview/llm.txt](/llms/manual/language-overview/llm.txt)
 - [/llms/manual/javascript-interop/llm.txt](/llms/manual/javascript-interop/llm.txt)
+- [/llms/manual/build-system/llm.txt](/llms/manual/build-system/llm.txt)
+- [/llms/manual/getting-started/llm.txt](/llms/manual/getting-started/llm.txt)
 `,
   );
 
@@ -171,6 +198,11 @@ test("generate_llms writes the default manual index at the site root", () => {
     root,
     "public/llms/manual/javascript-interop/llm.txt",
   );
+  let buildSystem = readFile(root, "public/llms/manual/build-system/llm.txt");
+  let gettingStarted = readFile(
+    root,
+    "public/llms/manual/getting-started/llm.txt",
+  );
   let manualVersions = ["v12", "v13"];
 
   assert.doesNotMatch(currentLlms, /<VERSION>/);
@@ -195,6 +227,14 @@ test("generate_llms writes the default manual index at the site root", () => {
     currentLlms,
     /https:\/\/rescript-lang\.org\/llms\/manual\/javascript-interop\/llm\.txt/,
   );
+  assert.match(
+    currentLlms,
+    /https:\/\/rescript-lang\.org\/llms\/manual\/build-system\/llm\.txt/,
+  );
+  assert.match(
+    currentLlms,
+    /https:\/\/rescript-lang\.org\/llms\/manual\/getting-started\/llm\.txt/,
+  );
   assert.doesNotMatch(currentLlms, /\/llms\/manual\/v10\//);
   assert.doesNotMatch(currentLlms, /\/llms\/manual\/v11\//);
   assert.match(languageOverview, /# ReScript Language Overview/);
@@ -204,6 +244,13 @@ test("generate_llms writes the default manual index at the site root", () => {
   assert.match(javascriptInterop, /# ReScript JavaScript Interop/);
   assert.match(javascriptInterop, /JavaScript interop content/);
   assert.doesNotMatch(javascriptInterop, /Language feature content/);
+  assert.match(buildSystem, /# ReScript Build System/);
+  assert.match(buildSystem, /Build system content/);
+  assert.doesNotMatch(buildSystem, /Manual Introduction/);
+  assert.match(gettingStarted, /# ReScript Getting Started/);
+  assert.match(gettingStarted, /Manual Introduction/);
+  assert.doesNotMatch(gettingStarted, /Manual LLMs/);
+  assert.doesNotMatch(gettingStarted, /Build system content/);
 
   assert.equal(
     fs.existsSync(path.join(root, "public/llms/manual/llms.txt")),
@@ -261,6 +308,14 @@ test("generate_llms writes the default manual index at the site root", () => {
         `public/llms/manual/${version}/javascript-interop/llm.txt`,
       ),
       javascriptInterop,
+    );
+    assert.equal(
+      readFile(root, `public/llms/manual/${version}/build-system/llm.txt`),
+      buildSystem,
+    );
+    assert.equal(
+      readFile(root, `public/llms/manual/${version}/getting-started/llm.txt`),
+      gettingStarted,
     );
     assert.match(
       readFile(root, `public/llms/manual/${version}/llms.txt`),

--- a/apps/docs/scripts/__tests__/generate-llms.test.mjs
+++ b/apps/docs/scripts/__tests__/generate-llms.test.mjs
@@ -101,13 +101,12 @@ title: "React Introduction"
 Current version: <VERSION>
 Version label: <MANUAL_VERSION_LABEL>
 
-- [Complete documentation](https://rescript-lang.org/llms/manual/<VERSION>/llm-full.txt)
-- [Abridged documentation](https://rescript-lang.org/llms/manual/<VERSION>/llm-small.txt)
+- [Complete documentation](https://rescript-lang.org/llms/manual/llm-full.txt)
+- [Abridged documentation](https://rescript-lang.org/llms/manual/llm-small.txt)
 - [Language overview](https://rescript-lang.org/llms/manual/language-overview/llm.txt)
 - [JavaScript interop](https://rescript-lang.org/llms/manual/javascript-interop/llm.txt)
 - [Build system](https://rescript-lang.org/llms/manual/build-system/llm.txt)
 - [Getting started](https://rescript-lang.org/llms/manual/getting-started/llm.txt)
-<MANUAL_VERSION_LINKS>
 `,
   );
   writeFile(root, "public/llms/manual/llms.txt", "stale manual index");
@@ -135,6 +134,8 @@ order: 4
 - [/llms/manual/javascript-interop/llm.txt](/llms/manual/javascript-interop/llm.txt)
 - [/llms/manual/build-system/llm.txt](/llms/manual/build-system/llm.txt)
 - [/llms/manual/getting-started/llm.txt](/llms/manual/getting-started/llm.txt)
+- [/llms/manual/v13/llm-full.txt](/llms/manual/v13/llm-full.txt)
+- [/llms/manual/v12/llm-full.txt](/llms/manual/v12/llm-full.txt)
 `,
   );
 
@@ -147,8 +148,8 @@ Current version: <VERSION>
 ReScript React package version: <RESCRIPT_REACT_VERSION>
 React version: <REACT_VERSION>
 
-- [Complete documentation](https://rescript-lang.org/llms/react/<VERSION>/llm-full.txt)
-- [Abridged documentation](https://rescript-lang.org/llms/react/<VERSION>/llm-small.txt)
+- [Complete documentation](https://rescript-lang.org/llms/react/llm-full.txt)
+- [Abridged documentation](https://rescript-lang.org/llms/react/llm-small.txt)
 `,
   );
 
@@ -168,17 +169,6 @@ React version: <REACT_VERSION>
 let readFile = (root, filePath) =>
   fs.readFileSync(path.join(root, filePath), "utf8");
 
-let assertOccursInOrder = (content, parts) => {
-  let lastIndex = -1;
-
-  for (let part of parts) {
-    let index = content.indexOf(part);
-    assert.notEqual(index, -1);
-    assert.ok(index > lastIndex);
-    lastIndex = index;
-  }
-};
-
 test("generate_llms writes the default manual index at the site root", () => {
   let root = makeWorkspace();
 
@@ -188,6 +178,7 @@ test("generate_llms writes the default manual index at the site root", () => {
   });
 
   let currentLlms = readFile(root, "public/llms.txt");
+  let humanLlmsPage = readFile(root, "markdown-pages/docs/manual/llms.mdx");
   let versionedLlms = readFile(root, "public/llms/manual/v12/llms.txt");
   let preReleaseLlms = readFile(root, "public/llms/manual/v13/llms.txt");
   let languageOverview = readFile(
@@ -209,15 +200,13 @@ test("generate_llms writes the default manual index at the site root", () => {
   assert.doesNotMatch(currentLlms, /<MANUAL_VERSION_LABEL>/);
   assert.match(currentLlms, /Current version: v12/);
   assert.match(currentLlms, /Version label: v12 \(current version\)/);
-  assert.match(currentLlms, /v12 current/i);
-  assert.match(currentLlms, /v13 pre-release/i);
   assert.match(
     currentLlms,
-    /https:\/\/rescript-lang\.org\/llms\/manual\/v12\/llm-full\.txt/,
+    /https:\/\/rescript-lang\.org\/llms\/manual\/llm-full\.txt/,
   );
   assert.match(
     currentLlms,
-    /https:\/\/rescript-lang\.org\/llms\/manual\/v12\/llm-small\.txt/,
+    /https:\/\/rescript-lang\.org\/llms\/manual\/llm-small\.txt/,
   );
   assert.match(
     currentLlms,
@@ -235,8 +224,12 @@ test("generate_llms writes the default manual index at the site root", () => {
     currentLlms,
     /https:\/\/rescript-lang\.org\/llms\/manual\/getting-started\/llm\.txt/,
   );
+  assert.doesNotMatch(currentLlms, /\/llms\/manual\/v12\//);
+  assert.doesNotMatch(currentLlms, /\/llms\/manual\/v13\//);
   assert.doesNotMatch(currentLlms, /\/llms\/manual\/v10\//);
   assert.doesNotMatch(currentLlms, /\/llms\/manual\/v11\//);
+  assert.match(humanLlmsPage, /\/llms\/manual\/v13\/llm-full\.txt/);
+  assert.match(humanLlmsPage, /\/llms\/manual\/v12\/llm-full\.txt/);
   assert.match(languageOverview, /# ReScript Language Overview/);
   assert.match(languageOverview, /Language feature content/);
   assert.doesNotMatch(languageOverview, /JavaScript interop content/);
@@ -284,12 +277,6 @@ test("generate_llms writes the default manual index at the site root", () => {
   assert.match(preReleaseLlms, /Version label: v13 \(pre-release version\)/);
 
   for (let version of manualVersions) {
-    assert.match(
-      currentLlms,
-      new RegExp(
-        `https://rescript-lang\\.org/llms/manual/${version}/llm-full\\.txt`,
-      ),
-    );
     assert.equal(
       readFile(root, `public/llms/manual/${version}/llm-full.txt`),
       readFile(root, "public/llms/manual/llm-full.txt"),
@@ -324,13 +311,6 @@ test("generate_llms writes the default manual index at the site root", () => {
   }
 
   assert.doesNotMatch(currentLlms, /v10\.|v11\.|v12\.|v13\./);
-  let majorVersionLinks = currentLlms.slice(
-    currentLlms.indexOf("v13 pre-release LLMs index"),
-  );
-  assertOccursInOrder(majorVersionLinks, [
-    "/llms/manual/v13/llm-full.txt",
-    "/llms/manual/v12/llm-full.txt",
-  ]);
 });
 
 test("generate_llms writes versioned ReScript React files", () => {
@@ -342,6 +322,7 @@ test("generate_llms writes versioned ReScript React files", () => {
   });
 
   let currentLlms = readFile(root, "public/llms/react/llms.txt");
+  let humanLlmsPage = readFile(root, "markdown-pages/docs/react/llms.mdx");
   let versionedLlms = readFile(root, "public/llms/react/v0.14.2/llms.txt");
 
   assert.doesNotMatch(currentLlms, /<VERSION>/);
@@ -351,12 +332,15 @@ test("generate_llms writes versioned ReScript React files", () => {
   assert.match(currentLlms, /React version: v19\.2\.4/);
   assert.match(
     currentLlms,
-    /https:\/\/rescript-lang\.org\/llms\/react\/v0\.14\.2\/llm-full\.txt/,
+    /https:\/\/rescript-lang\.org\/llms\/react\/llm-full\.txt/,
   );
   assert.match(
     currentLlms,
-    /https:\/\/rescript-lang\.org\/llms\/react\/v0\.14\.2\/llm-small\.txt/,
+    /https:\/\/rescript-lang\.org\/llms\/react\/llm-small\.txt/,
   );
+  assert.doesNotMatch(currentLlms, /\/llms\/react\/v0\.14\.2\//);
+  assert.match(humanLlmsPage, /\/llms\/react\/v0\.14\.2\/llm-full\.txt/);
+  assert.match(humanLlmsPage, /\/llms\/react\/v0\.14\.2\/llm-small\.txt/);
 
   assert.equal(
     fs.existsSync(path.join(root, "public/llms/react/latest/llms.txt")),

--- a/apps/docs/scripts/__tests__/generate-llms.test.mjs
+++ b/apps/docs/scripts/__tests__/generate-llms.test.mjs
@@ -37,6 +37,36 @@ let answer = 42
 
   writeFile(
     root,
+    "markdown-pages/docs/manual/overview.mdx",
+    `---
+title: "Language Overview"
+section: "Language Features"
+order: 1
+---
+
+# Language Overview
+
+Language feature content.
+`,
+  );
+
+  writeFile(
+    root,
+    "markdown-pages/docs/manual/bind-to-js-function.mdx",
+    `---
+title: "Bind to JS Function"
+section: "JavaScript Interop"
+order: 1
+---
+
+# Bind to JS Function
+
+JavaScript interop content.
+`,
+  );
+
+  writeFile(
+    root,
     "markdown-pages/docs/react/introduction.mdx",
     `---
 title: "React Introduction"
@@ -56,6 +86,8 @@ Version label: <MANUAL_VERSION_LABEL>
 
 - [Complete documentation](https://rescript-lang.org/llms/manual/<VERSION>/llm-full.txt)
 - [Abridged documentation](https://rescript-lang.org/llms/manual/<VERSION>/llm-small.txt)
+- [Language overview](https://rescript-lang.org/llms/manual/language-overview/llm.txt)
+- [JavaScript interop](https://rescript-lang.org/llms/manual/javascript-interop/llm.txt)
 <MANUAL_VERSION_LINKS>
 `,
   );
@@ -74,6 +106,8 @@ Version label: <MANUAL_VERSION_LABEL>
 
 - [/llms/manual/<VERSION>/llm-full.txt](/llms/manual/<VERSION>/llm-full.txt)
 - [/llms/manual/<VERSION>/llm-small.txt](/llms/manual/<VERSION>/llm-small.txt)
+- [/llms/manual/language-overview/llm.txt](/llms/manual/language-overview/llm.txt)
+- [/llms/manual/javascript-interop/llm.txt](/llms/manual/javascript-interop/llm.txt)
 `,
   );
 
@@ -129,6 +163,14 @@ test("generate_llms writes the default manual index at the site root", () => {
   let currentLlms = readFile(root, "public/llms.txt");
   let versionedLlms = readFile(root, "public/llms/manual/v12/llms.txt");
   let preReleaseLlms = readFile(root, "public/llms/manual/v13/llms.txt");
+  let languageOverview = readFile(
+    root,
+    "public/llms/manual/language-overview/llm.txt",
+  );
+  let javascriptInterop = readFile(
+    root,
+    "public/llms/manual/javascript-interop/llm.txt",
+  );
   let manualVersions = ["v12", "v13"];
 
   assert.doesNotMatch(currentLlms, /<VERSION>/);
@@ -145,8 +187,23 @@ test("generate_llms writes the default manual index at the site root", () => {
     currentLlms,
     /https:\/\/rescript-lang\.org\/llms\/manual\/v12\/llm-small\.txt/,
   );
+  assert.match(
+    currentLlms,
+    /https:\/\/rescript-lang\.org\/llms\/manual\/language-overview\/llm\.txt/,
+  );
+  assert.match(
+    currentLlms,
+    /https:\/\/rescript-lang\.org\/llms\/manual\/javascript-interop\/llm\.txt/,
+  );
   assert.doesNotMatch(currentLlms, /\/llms\/manual\/v10\//);
   assert.doesNotMatch(currentLlms, /\/llms\/manual\/v11\//);
+  assert.match(languageOverview, /# ReScript Language Overview/);
+  assert.match(languageOverview, /Language feature content/);
+  assert.doesNotMatch(languageOverview, /JavaScript interop content/);
+  assert.doesNotMatch(languageOverview, /Manual Introduction/);
+  assert.match(javascriptInterop, /# ReScript JavaScript Interop/);
+  assert.match(javascriptInterop, /JavaScript interop content/);
+  assert.doesNotMatch(javascriptInterop, /Language feature content/);
 
   assert.equal(
     fs.existsSync(path.join(root, "public/llms/manual/llms.txt")),
@@ -193,6 +250,17 @@ test("generate_llms writes the default manual index at the site root", () => {
     assert.equal(
       readFile(root, `public/llms/manual/${version}/llm-small.txt`),
       readFile(root, "public/llms/manual/llm-small.txt"),
+    );
+    assert.equal(
+      readFile(root, `public/llms/manual/${version}/language-overview/llm.txt`),
+      languageOverview,
+    );
+    assert.equal(
+      readFile(
+        root,
+        `public/llms/manual/${version}/javascript-interop/llm.txt`,
+      ),
+      javascriptInterop,
     );
     assert.match(
       readFile(root, `public/llms/manual/${version}/llms.txt`),

--- a/apps/docs/scripts/__tests__/generate-llms.test.mjs
+++ b/apps/docs/scripts/__tests__/generate-llms.test.mjs
@@ -98,8 +98,7 @@ title: "React Introduction"
     "public/llms/manual/template.txt",
     `# Manual LLMs
 
-Current version: <VERSION>
-Version label: <MANUAL_VERSION_LABEL>
+## Files
 
 - [Complete documentation](https://rescript-lang.org/llms/manual/llm-full.txt)
 - [Abridged documentation](https://rescript-lang.org/llms/manual/llm-small.txt)
@@ -128,12 +127,17 @@ order: 4
 
 # Manual LLMs
 
+## Files
+
 - [/llms/manual/<VERSION>/llm-full.txt](/llms/manual/<VERSION>/llm-full.txt)
 - [/llms/manual/<VERSION>/llm-small.txt](/llms/manual/<VERSION>/llm-small.txt)
 - [/llms/manual/language-overview/llm.txt](/llms/manual/language-overview/llm.txt)
 - [/llms/manual/javascript-interop/llm.txt](/llms/manual/javascript-interop/llm.txt)
 - [/llms/manual/build-system/llm.txt](/llms/manual/build-system/llm.txt)
 - [/llms/manual/getting-started/llm.txt](/llms/manual/getting-started/llm.txt)
+
+## Versioned Files
+
 - [/llms/manual/v13/llm-full.txt](/llms/manual/v13/llm-full.txt)
 - [/llms/manual/v12/llm-full.txt](/llms/manual/v12/llm-full.txt)
 `,
@@ -144,9 +148,7 @@ order: 4
     "public/llms/react/template.txt",
     `# React LLMs
 
-Current version: <VERSION>
-ReScript React package version: <RESCRIPT_REACT_VERSION>
-React version: <REACT_VERSION>
+## Files
 
 - [Complete documentation](https://rescript-lang.org/llms/react/llm-full.txt)
 - [Abridged documentation](https://rescript-lang.org/llms/react/llm-small.txt)
@@ -157,6 +159,13 @@ React version: <REACT_VERSION>
     root,
     "public/llms/react/template.mdx",
     `# React LLMs
+
+## Files
+
+- [/llms/react/llm-full.txt](/llms/react/llm-full.txt)
+- [/llms/react/llm-small.txt](/llms/react/llm-small.txt)
+
+## Versioned Files
 
 - [/llms/react/<VERSION>/llm-full.txt](/llms/react/<VERSION>/llm-full.txt)
 - [/llms/react/<VERSION>/llm-small.txt](/llms/react/<VERSION>/llm-small.txt)
@@ -180,7 +189,6 @@ test("generate_llms writes the default manual index at the site root", () => {
   let currentLlms = readFile(root, "public/llms.txt");
   let humanLlmsPage = readFile(root, "markdown-pages/docs/manual/llms.mdx");
   let versionedLlms = readFile(root, "public/llms/manual/v12/llms.txt");
-  let preReleaseLlms = readFile(root, "public/llms/manual/v13/llms.txt");
   let languageOverview = readFile(
     root,
     "public/llms/manual/language-overview/llm.txt",
@@ -198,8 +206,14 @@ test("generate_llms writes the default manual index at the site root", () => {
 
   assert.doesNotMatch(currentLlms, /<VERSION>/);
   assert.doesNotMatch(currentLlms, /<MANUAL_VERSION_LABEL>/);
-  assert.match(currentLlms, /Current version: v12/);
-  assert.match(currentLlms, /Version label: v12 \(current version\)/);
+  assert.doesNotMatch(currentLlms, /Current version/i);
+  assert.doesNotMatch(currentLlms, /Version label/i);
+  assert.doesNotMatch(currentLlms, /Default Current Files/i);
+  assert.doesNotMatch(currentLlms, /default entry point/i);
+  assert.doesNotMatch(humanLlmsPage, /This ReScript manual major version/i);
+  assert.doesNotMatch(humanLlmsPage, /Default Current Files/i);
+  assert.doesNotMatch(humanLlmsPage, /default entry point/i);
+  assert.match(humanLlmsPage, /## Versioned Files/);
   assert.match(
     currentLlms,
     /https:\/\/rescript-lang\.org\/llms\/manual\/llm-full\.txt/,
@@ -274,7 +288,6 @@ test("generate_llms writes the default manual index at the site root", () => {
     false,
   );
   assert.equal(versionedLlms, currentLlms);
-  assert.match(preReleaseLlms, /Version label: v13 \(pre-release version\)/);
 
   for (let version of manualVersions) {
     assert.equal(
@@ -304,9 +317,9 @@ test("generate_llms writes the default manual index at the site root", () => {
       readFile(root, `public/llms/manual/${version}/getting-started/llm.txt`),
       gettingStarted,
     );
-    assert.match(
+    assert.equal(
       readFile(root, `public/llms/manual/${version}/llms.txt`),
-      new RegExp(`Current version: ${version}`),
+      currentLlms,
     );
   }
 
@@ -327,9 +340,18 @@ test("generate_llms writes versioned ReScript React files", () => {
 
   assert.doesNotMatch(currentLlms, /<VERSION>/);
   assert.doesNotMatch(currentLlms, /<RESCRIPT_REACT_VERSION>|<REACT_VERSION>/);
-  assert.match(currentLlms, /Current version: v0\.14\.2/);
-  assert.match(currentLlms, /ReScript React package version: v0\.14\.2/);
-  assert.match(currentLlms, /React version: v19\.2\.4/);
+  assert.doesNotMatch(currentLlms, /Current version/i);
+  assert.doesNotMatch(currentLlms, /ReScript React package version/i);
+  assert.doesNotMatch(currentLlms, /React version/i);
+  assert.doesNotMatch(currentLlms, /Default Current Files/i);
+  assert.doesNotMatch(currentLlms, /default entry point/i);
+  assert.doesNotMatch(
+    humanLlmsPage,
+    /Current ReScript React documentation version/i,
+  );
+  assert.doesNotMatch(humanLlmsPage, /Default Current Files/i);
+  assert.doesNotMatch(humanLlmsPage, /default entry point/i);
+  assert.match(humanLlmsPage, /## Versioned Files/);
   assert.match(
     currentLlms,
     /https:\/\/rescript-lang\.org\/llms\/react\/llm-full\.txt/,

--- a/apps/docs/scripts/__tests__/generate-llms.test.mjs
+++ b/apps/docs/scripts/__tests__/generate-llms.test.mjs
@@ -115,6 +115,22 @@ title: "React Introduction"
   writeFile(root, "public/llms/manual/v11/llms.txt", "stale v11 index");
   writeFile(root, "public/llms/manual/v11/llm-full.txt", "stale v11 full");
   writeFile(root, "public/llms/manual/v11/llm-small.txt", "stale v11 small");
+  writeFile(root, "public/llms/manual/v12/llms.txt", "stale v12 index");
+  writeFile(root, "public/llms/manual/v12/llm-full.txt", "stale v12 full");
+  writeFile(root, "public/llms/manual/v12/llm-small.txt", "stale v12 small");
+  writeFile(
+    root,
+    "public/llms/manual/v12/language-overview/llm.txt",
+    "stale v12 language overview",
+  );
+  writeFile(root, "public/llms/manual/v13/llms.txt", "stale v13 index");
+  writeFile(root, "public/llms/manual/v13/llm-full.txt", "stale v13 full");
+  writeFile(root, "public/llms/manual/v13/llm-small.txt", "stale v13 small");
+  writeFile(
+    root,
+    "public/llms/manual/v13/language-overview/llm.txt",
+    "stale v13 language overview",
+  );
 
   writeFile(
     root,
@@ -129,17 +145,12 @@ order: 4
 
 ## Files
 
-- [/llms/manual/<VERSION>/llm-full.txt](/llms/manual/<VERSION>/llm-full.txt)
-- [/llms/manual/<VERSION>/llm-small.txt](/llms/manual/<VERSION>/llm-small.txt)
+- [/llms/manual/llm-full.txt](/llms/manual/llm-full.txt)
+- [/llms/manual/llm-small.txt](/llms/manual/llm-small.txt)
 - [/llms/manual/language-overview/llm.txt](/llms/manual/language-overview/llm.txt)
 - [/llms/manual/javascript-interop/llm.txt](/llms/manual/javascript-interop/llm.txt)
 - [/llms/manual/build-system/llm.txt](/llms/manual/build-system/llm.txt)
 - [/llms/manual/getting-started/llm.txt](/llms/manual/getting-started/llm.txt)
-
-## Versioned Files
-
-- [/llms/manual/v13/llm-full.txt](/llms/manual/v13/llm-full.txt)
-- [/llms/manual/v12/llm-full.txt](/llms/manual/v12/llm-full.txt)
 `,
   );
 
@@ -164,12 +175,29 @@ order: 4
 
 - [/llms/react/llm-full.txt](/llms/react/llm-full.txt)
 - [/llms/react/llm-small.txt](/llms/react/llm-small.txt)
-
-## Versioned Files
-
-- [/llms/react/<VERSION>/llm-full.txt](/llms/react/<VERSION>/llm-full.txt)
-- [/llms/react/<VERSION>/llm-small.txt](/llms/react/<VERSION>/llm-small.txt)
 `,
+  );
+  writeFile(
+    root,
+    "public/llms/react/v0.14.2/llms.txt",
+    "stale react versioned index",
+  );
+  writeFile(
+    root,
+    "public/llms/react/v0.14.2/llm-full.txt",
+    "stale react versioned full",
+  );
+  writeFile(
+    root,
+    "public/llms/react/v0.14.2/llm-small.txt",
+    "stale react versioned small",
+  );
+  writeFile(root, "public/llms/react/latest/llms.txt", "stale latest index");
+  writeFile(root, "public/llms/react/latest/llm-full.txt", "stale latest full");
+  writeFile(
+    root,
+    "public/llms/react/latest/llm-small.txt",
+    "stale latest small",
   );
 
   return root;
@@ -188,7 +216,6 @@ test("generate_llms writes the default manual index at the site root", () => {
 
   let currentLlms = readFile(root, "public/llms.txt");
   let humanLlmsPage = readFile(root, "markdown-pages/docs/manual/llms.mdx");
-  let versionedLlms = readFile(root, "public/llms/manual/v12/llms.txt");
   let languageOverview = readFile(
     root,
     "public/llms/manual/language-overview/llm.txt",
@@ -202,7 +229,6 @@ test("generate_llms writes the default manual index at the site root", () => {
     root,
     "public/llms/manual/getting-started/llm.txt",
   );
-  let manualVersions = ["v12", "v13"];
 
   assert.doesNotMatch(currentLlms, /<VERSION>/);
   assert.doesNotMatch(currentLlms, /<MANUAL_VERSION_LABEL>/);
@@ -213,7 +239,7 @@ test("generate_llms writes the default manual index at the site root", () => {
   assert.doesNotMatch(humanLlmsPage, /This ReScript manual major version/i);
   assert.doesNotMatch(humanLlmsPage, /Default Current Files/i);
   assert.doesNotMatch(humanLlmsPage, /default entry point/i);
-  assert.match(humanLlmsPage, /## Versioned Files/);
+  assert.doesNotMatch(humanLlmsPage, /## Versioned Files/);
   assert.match(
     currentLlms,
     /https:\/\/rescript-lang\.org\/llms\/manual\/llm-full\.txt/,
@@ -242,8 +268,8 @@ test("generate_llms writes the default manual index at the site root", () => {
   assert.doesNotMatch(currentLlms, /\/llms\/manual\/v13\//);
   assert.doesNotMatch(currentLlms, /\/llms\/manual\/v10\//);
   assert.doesNotMatch(currentLlms, /\/llms\/manual\/v11\//);
-  assert.match(humanLlmsPage, /\/llms\/manual\/v13\/llm-full\.txt/);
-  assert.match(humanLlmsPage, /\/llms\/manual\/v12\/llm-full\.txt/);
+  assert.doesNotMatch(humanLlmsPage, /\/llms\/manual\/v13\//);
+  assert.doesNotMatch(humanLlmsPage, /\/llms\/manual\/v12\//);
   assert.match(languageOverview, /# ReScript Language Overview/);
   assert.match(languageOverview, /Language feature content/);
   assert.doesNotMatch(languageOverview, /JavaScript interop content/);
@@ -287,46 +313,38 @@ test("generate_llms writes the default manual index at the site root", () => {
     fs.existsSync(path.join(root, "public/llms/manual/v11/llm-small.txt")),
     false,
   );
-  assert.equal(versionedLlms, currentLlms);
-
-  for (let version of manualVersions) {
+  for (let version of ["v12", "v13"]) {
     assert.equal(
-      readFile(root, `public/llms/manual/${version}/llm-full.txt`),
-      readFile(root, "public/llms/manual/llm-full.txt"),
+      fs.existsSync(path.join(root, `public/llms/manual/${version}/llms.txt`)),
+      false,
     );
     assert.equal(
-      readFile(root, `public/llms/manual/${version}/llm-small.txt`),
-      readFile(root, "public/llms/manual/llm-small.txt"),
-    );
-    assert.equal(
-      readFile(root, `public/llms/manual/${version}/language-overview/llm.txt`),
-      languageOverview,
-    );
-    assert.equal(
-      readFile(
-        root,
-        `public/llms/manual/${version}/javascript-interop/llm.txt`,
+      fs.existsSync(
+        path.join(root, `public/llms/manual/${version}/llm-full.txt`),
       ),
-      javascriptInterop,
+      false,
     );
     assert.equal(
-      readFile(root, `public/llms/manual/${version}/build-system/llm.txt`),
-      buildSystem,
+      fs.existsSync(
+        path.join(root, `public/llms/manual/${version}/llm-small.txt`),
+      ),
+      false,
     );
     assert.equal(
-      readFile(root, `public/llms/manual/${version}/getting-started/llm.txt`),
-      gettingStarted,
-    );
-    assert.equal(
-      readFile(root, `public/llms/manual/${version}/llms.txt`),
-      currentLlms,
+      fs.existsSync(
+        path.join(
+          root,
+          `public/llms/manual/${version}/language-overview/llm.txt`,
+        ),
+      ),
+      false,
     );
   }
 
   assert.doesNotMatch(currentLlms, /v10\.|v11\.|v12\.|v13\./);
 });
 
-test("generate_llms writes versioned ReScript React files", () => {
+test("generate_llms writes ReScript React files", () => {
   let root = makeWorkspace();
 
   child_process.execFileSync(process.execPath, [generatorPath], {
@@ -336,7 +354,6 @@ test("generate_llms writes versioned ReScript React files", () => {
 
   let currentLlms = readFile(root, "public/llms/react/llms.txt");
   let humanLlmsPage = readFile(root, "markdown-pages/docs/react/llms.mdx");
-  let versionedLlms = readFile(root, "public/llms/react/v0.14.2/llms.txt");
 
   assert.doesNotMatch(currentLlms, /<VERSION>/);
   assert.doesNotMatch(currentLlms, /<RESCRIPT_REACT_VERSION>|<REACT_VERSION>/);
@@ -351,7 +368,7 @@ test("generate_llms writes versioned ReScript React files", () => {
   );
   assert.doesNotMatch(humanLlmsPage, /Default Current Files/i);
   assert.doesNotMatch(humanLlmsPage, /default entry point/i);
-  assert.match(humanLlmsPage, /## Versioned Files/);
+  assert.doesNotMatch(humanLlmsPage, /## Versioned Files/);
   assert.match(
     currentLlms,
     /https:\/\/rescript-lang\.org\/llms\/react\/llm-full\.txt/,
@@ -361,20 +378,30 @@ test("generate_llms writes versioned ReScript React files", () => {
     /https:\/\/rescript-lang\.org\/llms\/react\/llm-small\.txt/,
   );
   assert.doesNotMatch(currentLlms, /\/llms\/react\/v0\.14\.2\//);
-  assert.match(humanLlmsPage, /\/llms\/react\/v0\.14\.2\/llm-full\.txt/);
-  assert.match(humanLlmsPage, /\/llms\/react\/v0\.14\.2\/llm-small\.txt/);
+  assert.doesNotMatch(humanLlmsPage, /\/llms\/react\/v0\.14\.2\//);
 
   assert.equal(
     fs.existsSync(path.join(root, "public/llms/react/latest/llms.txt")),
     false,
   );
-  assert.equal(versionedLlms, currentLlms);
   assert.equal(
-    readFile(root, "public/llms/react/v0.14.2/llm-full.txt"),
-    readFile(root, "public/llms/react/llm-full.txt"),
+    fs.existsSync(path.join(root, "public/llms/react/latest/llm-full.txt")),
+    false,
   );
   assert.equal(
-    readFile(root, "public/llms/react/v0.14.2/llm-small.txt"),
-    readFile(root, "public/llms/react/llm-small.txt"),
+    fs.existsSync(path.join(root, "public/llms/react/latest/llm-small.txt")),
+    false,
+  );
+  assert.equal(
+    fs.existsSync(path.join(root, "public/llms/react/v0.14.2/llms.txt")),
+    false,
+  );
+  assert.equal(
+    fs.existsSync(path.join(root, "public/llms/react/v0.14.2/llm-full.txt")),
+    false,
+  );
+  assert.equal(
+    fs.existsSync(path.join(root, "public/llms/react/v0.14.2/llm-small.txt")),
+    false,
   );
 });

--- a/apps/docs/scripts/generate_llms.res
+++ b/apps/docs/scripts/generate_llms.res
@@ -423,13 +423,13 @@ let manualVersionLinks = `- [v13 pre-release LLMs index](https://rescript-lang.o
 - [v13 pre-release JavaScript interop](https://rescript-lang.org/llms/manual/v13/javascript-interop/llm.txt): Focused latest ReScript v13 pre-release JavaScript interop reference
 - [v13 pre-release build system](https://rescript-lang.org/llms/manual/v13/build-system/llm.txt): Focused latest ReScript v13 pre-release build system reference
 - [v13 pre-release getting started](https://rescript-lang.org/llms/manual/v13/getting-started/llm.txt): Focused latest ReScript v13 pre-release onboarding reference
-- [v12 current LLMs index](https://rescript-lang.org/llms/manual/v12/llms.txt): The LLM file list for the current ReScript v12 documentation
-- [v12 current complete documentation](https://rescript-lang.org/llms/manual/v12/llm-full.txt): The complete current ReScript v12 documentation
-- [v12 current abridged documentation](https://rescript-lang.org/llms/manual/v12/llm-small.txt): A minimal current ReScript v12 reference
-- [v12 current language overview](https://rescript-lang.org/llms/manual/v12/language-overview/llm.txt): Focused current ReScript v12 language overview
-- [v12 current JavaScript interop](https://rescript-lang.org/llms/manual/v12/javascript-interop/llm.txt): Focused current ReScript v12 JavaScript interop reference
-- [v12 current build system](https://rescript-lang.org/llms/manual/v12/build-system/llm.txt): Focused current ReScript v12 build system reference
-- [v12 current getting started](https://rescript-lang.org/llms/manual/v12/getting-started/llm.txt): Focused current ReScript v12 onboarding reference`
+- [v12 LLMs index](https://rescript-lang.org/llms/manual/v12/llms.txt): The LLM file list for ReScript v12 documentation
+- [v12 complete documentation](https://rescript-lang.org/llms/manual/v12/llm-full.txt): The complete ReScript v12 documentation
+- [v12 abridged documentation](https://rescript-lang.org/llms/manual/v12/llm-small.txt): A minimal ReScript v12 reference
+- [v12 language overview](https://rescript-lang.org/llms/manual/v12/language-overview/llm.txt): Focused ReScript v12 language overview
+- [v12 JavaScript interop](https://rescript-lang.org/llms/manual/v12/javascript-interop/llm.txt): Focused ReScript v12 JavaScript interop reference
+- [v12 build system](https://rescript-lang.org/llms/manual/v12/build-system/llm.txt): Focused ReScript v12 build system reference
+- [v12 getting started](https://rescript-lang.org/llms/manual/v12/getting-started/llm.txt): Focused ReScript v12 onboarding reference`
 
 let manualDocsDirectory = "markdown-pages/docs/manual"
 let reactDocsDirectory = "markdown-pages/docs/react"

--- a/apps/docs/scripts/generate_llms.res
+++ b/apps/docs/scripts/generate_llms.res
@@ -57,10 +57,12 @@ type sectionLlmFile = {
   slug: string,
   section: string,
   description: string,
+  excludedSlugs: array<string>,
 }
 
 type mdxDocument = {
   title: string,
+  slug: string,
   section: string,
   order: option<float>,
   content: string,
@@ -98,6 +100,7 @@ let readMdxDocument = (filePath: string): mdxDocument => {
   let {frontmatter}: MarkdownParser.result = rawContent->MarkdownParser.parseSync
   {
     title: frontmatter->getFrontmatterString("title"),
+    slug: filePath->Node.Path.basename->String.replace(".mdx", ""),
     section: frontmatter->getFrontmatterString("section"),
     order: frontmatter->getFrontmatterNumber("order"),
     content: rawContent->removeFrontmatter->String.trim,
@@ -127,7 +130,10 @@ let createSectionLlmFiles = (
 ): unit => {
   sectionFiles->Array.forEach(sectionFile => {
     let sectionDocuments =
-      documents->Array.filter(document => document.section === sectionFile.section)
+      documents->Array.filter(document =>
+        document.section === sectionFile.section &&
+          !(sectionFile.excludedSlugs->Array.some(excludedSlug => excludedSlug === document.slug))
+      )
     let content =
       sectionDocuments
       ->Array.map(document => document.content)
@@ -385,12 +391,28 @@ let manualSectionLlmFiles = [
     slug: "language-overview",
     section: "Language Features",
     description: "Focused documentation for ReScript syntax, data types, control flow, modules, and core language features.",
+    excludedSlugs: [],
   },
   {
     title: "ReScript JavaScript Interop",
     slug: "javascript-interop",
     section: "JavaScript Interop",
     description: "Focused documentation for binding to JavaScript values, modules, functions, objects, JSON, TypeScript, and other runtime interop patterns.",
+    excludedSlugs: [],
+  },
+  {
+    title: "ReScript Build System",
+    slug: "build-system",
+    section: "Build System",
+    description: "Focused documentation for ReScript build configuration, project structure, monorepo setup, compiler performance, and build-tool integration.",
+    excludedSlugs: [],
+  },
+  {
+    title: "ReScript Getting Started",
+    slug: "getting-started",
+    section: "Overview",
+    description: "Focused documentation for installing ReScript, editor setup, migration notes, and onboarding from JavaScript.",
+    excludedSlugs: ["llms"],
   },
 ]
 
@@ -399,11 +421,15 @@ let manualVersionLinks = `- [v13 pre-release LLMs index](https://rescript-lang.o
 - [v13 pre-release abridged documentation](https://rescript-lang.org/llms/manual/v13/llm-small.txt): A minimal latest ReScript v13 pre-release reference
 - [v13 pre-release language overview](https://rescript-lang.org/llms/manual/v13/language-overview/llm.txt): Focused latest ReScript v13 pre-release language overview
 - [v13 pre-release JavaScript interop](https://rescript-lang.org/llms/manual/v13/javascript-interop/llm.txt): Focused latest ReScript v13 pre-release JavaScript interop reference
+- [v13 pre-release build system](https://rescript-lang.org/llms/manual/v13/build-system/llm.txt): Focused latest ReScript v13 pre-release build system reference
+- [v13 pre-release getting started](https://rescript-lang.org/llms/manual/v13/getting-started/llm.txt): Focused latest ReScript v13 pre-release onboarding reference
 - [v12 current LLMs index](https://rescript-lang.org/llms/manual/v12/llms.txt): The LLM file list for the current ReScript v12 documentation
 - [v12 current complete documentation](https://rescript-lang.org/llms/manual/v12/llm-full.txt): The complete current ReScript v12 documentation
 - [v12 current abridged documentation](https://rescript-lang.org/llms/manual/v12/llm-small.txt): A minimal current ReScript v12 reference
 - [v12 current language overview](https://rescript-lang.org/llms/manual/v12/language-overview/llm.txt): Focused current ReScript v12 language overview
-- [v12 current JavaScript interop](https://rescript-lang.org/llms/manual/v12/javascript-interop/llm.txt): Focused current ReScript v12 JavaScript interop reference`
+- [v12 current JavaScript interop](https://rescript-lang.org/llms/manual/v12/javascript-interop/llm.txt): Focused current ReScript v12 JavaScript interop reference
+- [v12 current build system](https://rescript-lang.org/llms/manual/v12/build-system/llm.txt): Focused current ReScript v12 build system reference
+- [v12 current getting started](https://rescript-lang.org/llms/manual/v12/getting-started/llm.txt): Focused current ReScript v12 onboarding reference`
 
 let manualDocsDirectory = "markdown-pages/docs/manual"
 let reactDocsDirectory = "markdown-pages/docs/react"

--- a/apps/docs/scripts/generate_llms.res
+++ b/apps/docs/scripts/generate_llms.res
@@ -32,10 +32,6 @@ let writeTextFile = (filePath: string, content: string): unit => {
   Node.Fs.writeFileSync(filePath, content, ~encoding="utf8")
 }
 
-let copyFile = (sourcePath: string, targetPath: string): unit => {
-  writeTextFile(targetPath, readMarkdownFile(sourcePath))
-}
-
 let removeLlmsTextFiles = (~llmsDirectory: string): unit => {
   removeFileIfExists(llmsDirectory->Node.Path.join2("llms.txt"))
   removeFileIfExists(llmsDirectory->Node.Path.join2("llm-full.txt"))
@@ -208,32 +204,20 @@ let replacePlaceholder = (content: string, placeholder: string, value: string): 
   String.replaceRegExp(content, regex, value)
 }
 
-let manualVersionLabel = (version: string): string => {
-  switch version {
-  | "v12" => "v12 (current version)"
-  | "v13" => "v13 (pre-release version)"
-  | version => version
-  }
-}
-
 let renderTemplate = (
   content: string,
   ~version: string,
-  ~manualVersionLinks: string,
   ~rescriptReactVersion: string,
   ~reactVersion: string,
 ): string => {
   content
   ->replacePlaceholder("<VERSION>", version)
-  ->replacePlaceholder("<MANUAL_VERSION_LABEL>", version->manualVersionLabel)
-  ->replacePlaceholder("<MANUAL_VERSION_LINKS>", manualVersionLinks)
   ->replacePlaceholder("<RESCRIPT_REACT_VERSION>", rescriptReactVersion)
   ->replacePlaceholder("<REACT_VERSION>", reactVersion)
 }
 
 let createLlmsFiles = (
   ~version: string,
-  ~manualVersionLinks: string,
   ~rescriptReactVersion: string,
   ~reactVersion: string,
   ~txtFilePath: string,
@@ -250,7 +234,6 @@ let createLlmsFiles = (
     mdxFilePath,
     readMarkdownFile(mdxFileTemplatePath)->renderTemplate(
       ~version,
-      ~manualVersionLinks,
       ~rescriptReactVersion,
       ~reactVersion,
     ),
@@ -260,53 +243,14 @@ let createLlmsFiles = (
     txtFilePath,
     readMarkdownFile(txtFileTemplatePath)->renderTemplate(
       ~version,
-      ~manualVersionLinks,
       ~rescriptReactVersion,
       ~reactVersion,
     ),
   )
-}
-
-let copyCurrentFilesToVersion = (
-  ~version: string,
-  ~llmsDirectory: string,
-  ~fullFilePath: string,
-  ~smallFilePath: string,
-  ~sectionFiles: array<sectionLlmFile>,
-  ~manualVersionLinks: string,
-  ~rescriptReactVersion: string,
-  ~reactVersion: string,
-): unit => {
-  let versionedLlmsDirectory = llmsDirectory->Node.Path.join2(version)
-  let txtFileTemplatePath = llmsDirectory->Node.Path.join2("template.txt")
-
-  createDirectoryIfNotExists(versionedLlmsDirectory)
-  writeTextFile(
-    versionedLlmsDirectory->Node.Path.join2("llms.txt"),
-    readMarkdownFile(txtFileTemplatePath)->renderTemplate(
-      ~version,
-      ~manualVersionLinks,
-      ~rescriptReactVersion,
-      ~reactVersion,
-    ),
-  )
-  copyFile(fullFilePath, versionedLlmsDirectory->Node.Path.join2("llm-full.txt"))
-  copyFile(smallFilePath, versionedLlmsDirectory->Node.Path.join2("llm-small.txt"))
-  sectionFiles->Array.forEach(sectionFile => {
-    let sectionFilePath = sectionLlmFilePath(~llmsDirectory, sectionFile)
-    let versionedSectionFilePath = sectionLlmFilePath(
-      ~llmsDirectory=versionedLlmsDirectory,
-      sectionFile,
-    )
-    createDirectoryIfNotExists(Node.Path.dirname(versionedSectionFilePath))
-    copyFile(sectionFilePath, versionedSectionFilePath)
-  })
 }
 
 let generateFile = (
   ~currentVersion: string,
-  ~copyVersions: array<string>,
-  ~manualVersionLinks: string,
   ~rescriptReactVersion: string,
   ~reactVersion: string,
   ~txtFilePath: string,
@@ -340,7 +284,6 @@ let generateFile = (
 
   createLlmsFiles(
     ~version=currentVersion,
-    ~manualVersionLinks,
     ~rescriptReactVersion,
     ~reactVersion,
     ~txtFilePath,
@@ -364,23 +307,9 @@ let generateFile = (
   let documents = mdxFilePaths->Array.map(readMdxDocument)->Array.toSorted(compareMdxDocuments)
 
   createSectionLlmFiles(~llmsDirectory, ~sectionFiles, ~documents)
-
-  copyVersions->Array.forEach(version =>
-    copyCurrentFilesToVersion(
-      ~version,
-      ~llmsDirectory,
-      ~fullFilePath,
-      ~smallFilePath,
-      ~sectionFiles,
-      ~manualVersionLinks,
-      ~rescriptReactVersion,
-      ~reactVersion,
-    )
-  )
 }
 
 let currentManualVersion = "v12"
-let manualMajorVersions = ["v12", "v13"]
 
 let currentReactVersion = "v0.14.2"
 let currentReactRuntimeVersion = "v19.2.4"
@@ -416,21 +345,6 @@ let manualSectionLlmFiles = [
   },
 ]
 
-let manualVersionLinks = `- [v13 pre-release LLMs index](https://rescript-lang.org/llms/manual/v13/llms.txt): The LLM file list for the latest ReScript v13 pre-release documentation
-- [v13 pre-release complete documentation](https://rescript-lang.org/llms/manual/v13/llm-full.txt): The complete latest ReScript v13 pre-release documentation
-- [v13 pre-release abridged documentation](https://rescript-lang.org/llms/manual/v13/llm-small.txt): A minimal latest ReScript v13 pre-release reference
-- [v13 pre-release language overview](https://rescript-lang.org/llms/manual/v13/language-overview/llm.txt): Focused latest ReScript v13 pre-release language overview
-- [v13 pre-release JavaScript interop](https://rescript-lang.org/llms/manual/v13/javascript-interop/llm.txt): Focused latest ReScript v13 pre-release JavaScript interop reference
-- [v13 pre-release build system](https://rescript-lang.org/llms/manual/v13/build-system/llm.txt): Focused latest ReScript v13 pre-release build system reference
-- [v13 pre-release getting started](https://rescript-lang.org/llms/manual/v13/getting-started/llm.txt): Focused latest ReScript v13 pre-release onboarding reference
-- [v12 LLMs index](https://rescript-lang.org/llms/manual/v12/llms.txt): The LLM file list for ReScript v12 documentation
-- [v12 complete documentation](https://rescript-lang.org/llms/manual/v12/llm-full.txt): The complete ReScript v12 documentation
-- [v12 abridged documentation](https://rescript-lang.org/llms/manual/v12/llm-small.txt): A minimal ReScript v12 reference
-- [v12 language overview](https://rescript-lang.org/llms/manual/v12/language-overview/llm.txt): Focused ReScript v12 language overview
-- [v12 JavaScript interop](https://rescript-lang.org/llms/manual/v12/javascript-interop/llm.txt): Focused ReScript v12 JavaScript interop reference
-- [v12 build system](https://rescript-lang.org/llms/manual/v12/build-system/llm.txt): Focused ReScript v12 build system reference
-- [v12 getting started](https://rescript-lang.org/llms/manual/v12/getting-started/llm.txt): Focused ReScript v12 onboarding reference`
-
 let manualDocsDirectory = "markdown-pages/docs/manual"
 let reactDocsDirectory = "markdown-pages/docs/react"
 
@@ -439,25 +353,21 @@ let reactLlmsDirectory = "public/llms/react"
 
 generateFile(
   ~currentVersion=currentManualVersion,
-  ~copyVersions=manualMajorVersions,
-  ~manualVersionLinks,
   ~rescriptReactVersion="",
   ~reactVersion="",
   ~txtFilePath="public/llms.txt",
   ~staleTxtFilePath="public/llms/manual/llms.txt",
-  ~staleVersions=["v10", "v11"],
+  ~staleVersions=["v10", "v11", "v12", "v13"],
   ~sectionFiles=manualSectionLlmFiles,
   manualDocsDirectory,
   manualLlmsDirectory,
 )
 generateFile(
   ~currentVersion=currentReactVersion,
-  ~copyVersions=[currentReactVersion],
-  ~manualVersionLinks="",
   ~rescriptReactVersion=currentReactVersion,
   ~reactVersion=currentReactRuntimeVersion,
   ~txtFilePath=reactLlmsDirectory->Node.Path.join2("llms.txt"),
-  ~staleVersions=["latest"],
+  ~staleVersions=["latest", currentReactVersion],
   reactDocsDirectory,
   reactLlmsDirectory,
 )

--- a/apps/docs/scripts/generate_llms.res
+++ b/apps/docs/scripts/generate_llms.res
@@ -42,10 +42,119 @@ let removeLlmsTextFiles = (~llmsDirectory: string): unit => {
   removeFileIfExists(llmsDirectory->Node.Path.join2("llm-small.txt"))
 }
 
-let createDirectoryIfNotExists = (dirPath: string): unit => {
+let rec createDirectoryIfNotExists = (dirPath: string): unit => {
   if !Node.Fs.existsSync(dirPath) {
+    let parentPath = Node.Path.dirname(dirPath)
+    if parentPath !== "" && parentPath !== dirPath {
+      createDirectoryIfNotExists(parentPath)
+    }
     Node.Fs.mkdirSync(dirPath)
   }
+}
+
+type sectionLlmFile = {
+  title: string,
+  slug: string,
+  section: string,
+  description: string,
+}
+
+type mdxDocument = {
+  title: string,
+  section: string,
+  order: option<float>,
+  content: string,
+}
+
+let getFrontmatterString = (frontmatter: JSON.t, fieldName: string): string => {
+  switch frontmatter {
+  | Object(dict) =>
+    switch dict->Dict.get(fieldName) {
+    | Some(String(value)) => value
+    | _ => ""
+    }
+  | _ => ""
+  }
+}
+
+let getFrontmatterNumber = (frontmatter: JSON.t, fieldName: string): option<float> => {
+  switch frontmatter {
+  | Object(dict) =>
+    switch dict->Dict.get(fieldName) {
+    | Some(Number(value)) => Some(value)
+    | _ => None
+    }
+  | _ => None
+  }
+}
+
+let removeFrontmatter = (content: string): string => {
+  let regex = RegExp.fromString("^---[\\s\\S]*?---\\s*", ~flags="")
+  String.replaceRegExp(content, regex, "")
+}
+
+let readMdxDocument = (filePath: string): mdxDocument => {
+  let rawContent = filePath->readMarkdownFile
+  let {frontmatter}: MarkdownParser.result = rawContent->MarkdownParser.parseSync
+  {
+    title: frontmatter->getFrontmatterString("title"),
+    section: frontmatter->getFrontmatterString("section"),
+    order: frontmatter->getFrontmatterNumber("order"),
+    content: rawContent->removeFrontmatter->String.trim,
+  }
+}
+
+let compareMdxDocuments = (a: mdxDocument, b: mdxDocument): float => {
+  switch (a.order, b.order) {
+  | (Some(orderA), Some(orderB)) =>
+    switch Float.compare(orderA, orderB) {
+    | 0. => String.compare(a.title, b.title)
+    | result => result
+    }
+  | (Some(_), None) => -1.0
+  | (None, Some(_)) => 1.0
+  | (None, None) => String.compare(a.title, b.title)
+  }
+}
+
+let sectionLlmFilePath = (~llmsDirectory: string, sectionFile: sectionLlmFile): string =>
+  llmsDirectory->Node.Path.join2(sectionFile.slug)->Node.Path.join2("llm.txt")
+
+let createSectionLlmFiles = (
+  ~llmsDirectory: string,
+  ~sectionFiles: array<sectionLlmFile>,
+  ~documents: array<mdxDocument>,
+): unit => {
+  sectionFiles->Array.forEach(sectionFile => {
+    let sectionDocuments =
+      documents->Array.filter(document => document.section === sectionFile.section)
+    let content =
+      sectionDocuments
+      ->Array.map(document => document.content)
+      ->Array.join("\n")
+      ->String.trim
+
+    let filePath = sectionLlmFilePath(~llmsDirectory, sectionFile)
+    createDirectoryIfNotExists(Node.Path.dirname(filePath))
+    writeTextFile(
+      filePath,
+      `# ${sectionFile.title}
+
+${sectionFile.description}
+
+${content}
+`,
+    )
+  })
+}
+
+let removeSectionLlmFiles = (
+  ~llmsDirectory: string,
+  ~sectionFiles: array<sectionLlmFile>,
+): unit => {
+  sectionFiles->Array.forEach(sectionFile =>
+    removeFileIfExists(sectionLlmFilePath(~llmsDirectory, sectionFile))
+  )
 }
 
 let removeCodeTabTags = (content: string): string => {
@@ -157,6 +266,7 @@ let copyCurrentFilesToVersion = (
   ~llmsDirectory: string,
   ~fullFilePath: string,
   ~smallFilePath: string,
+  ~sectionFiles: array<sectionLlmFile>,
   ~manualVersionLinks: string,
   ~rescriptReactVersion: string,
   ~reactVersion: string,
@@ -176,6 +286,15 @@ let copyCurrentFilesToVersion = (
   )
   copyFile(fullFilePath, versionedLlmsDirectory->Node.Path.join2("llm-full.txt"))
   copyFile(smallFilePath, versionedLlmsDirectory->Node.Path.join2("llm-small.txt"))
+  sectionFiles->Array.forEach(sectionFile => {
+    let sectionFilePath = sectionLlmFilePath(~llmsDirectory, sectionFile)
+    let versionedSectionFilePath = sectionLlmFilePath(
+      ~llmsDirectory=versionedLlmsDirectory,
+      sectionFile,
+    )
+    createDirectoryIfNotExists(Node.Path.dirname(versionedSectionFilePath))
+    copyFile(sectionFilePath, versionedSectionFilePath)
+  })
 }
 
 let generateFile = (
@@ -187,6 +306,7 @@ let generateFile = (
   ~txtFilePath: string,
   ~staleTxtFilePath: option<string>=?,
   ~staleVersions: array<string>,
+  ~sectionFiles: array<sectionLlmFile>=[],
   docsDirectory: string,
   llmsDirectory: string,
 ): unit => {
@@ -206,9 +326,11 @@ let generateFile = (
   | None => ()
   }
 
-  staleVersions->Array.forEach(version =>
-    removeLlmsTextFiles(~llmsDirectory=llmsDirectory->Node.Path.join2(version))
-  )
+  staleVersions->Array.forEach(version => {
+    let versionedLlmsDirectory = llmsDirectory->Node.Path.join2(version)
+    removeLlmsTextFiles(~llmsDirectory=versionedLlmsDirectory)
+    removeSectionLlmFiles(~llmsDirectory=versionedLlmsDirectory, ~sectionFiles)
+  })
 
   createLlmsFiles(
     ~version=currentVersion,
@@ -220,9 +342,10 @@ let generateFile = (
     llmsDirectory,
   )
 
-  docsDirectory
-  ->collectFiles
-  ->Array.forEach(filePath => {
+  let mdxFilePaths =
+    docsDirectory->collectFiles->Array.filter(filePath => String.endsWith(filePath, ".mdx"))
+
+  mdxFilePaths->Array.forEach(filePath => {
     if String.endsWith(filePath, ".mdx") {
       let content = readMarkdownFile(filePath)
 
@@ -232,12 +355,17 @@ let generateFile = (
     }
   })
 
+  let documents = mdxFilePaths->Array.map(readMdxDocument)->Array.toSorted(compareMdxDocuments)
+
+  createSectionLlmFiles(~llmsDirectory, ~sectionFiles, ~documents)
+
   copyVersions->Array.forEach(version =>
     copyCurrentFilesToVersion(
       ~version,
       ~llmsDirectory,
       ~fullFilePath,
       ~smallFilePath,
+      ~sectionFiles,
       ~manualVersionLinks,
       ~rescriptReactVersion,
       ~reactVersion,
@@ -251,12 +379,31 @@ let manualMajorVersions = ["v12", "v13"]
 let currentReactVersion = "v0.14.2"
 let currentReactRuntimeVersion = "v19.2.4"
 
+let manualSectionLlmFiles = [
+  {
+    title: "ReScript Language Overview",
+    slug: "language-overview",
+    section: "Language Features",
+    description: "Focused documentation for ReScript syntax, data types, control flow, modules, and core language features.",
+  },
+  {
+    title: "ReScript JavaScript Interop",
+    slug: "javascript-interop",
+    section: "JavaScript Interop",
+    description: "Focused documentation for binding to JavaScript values, modules, functions, objects, JSON, TypeScript, and other runtime interop patterns.",
+  },
+]
+
 let manualVersionLinks = `- [v13 pre-release LLMs index](https://rescript-lang.org/llms/manual/v13/llms.txt): The LLM file list for the latest ReScript v13 pre-release documentation
 - [v13 pre-release complete documentation](https://rescript-lang.org/llms/manual/v13/llm-full.txt): The complete latest ReScript v13 pre-release documentation
 - [v13 pre-release abridged documentation](https://rescript-lang.org/llms/manual/v13/llm-small.txt): A minimal latest ReScript v13 pre-release reference
+- [v13 pre-release language overview](https://rescript-lang.org/llms/manual/v13/language-overview/llm.txt): Focused latest ReScript v13 pre-release language overview
+- [v13 pre-release JavaScript interop](https://rescript-lang.org/llms/manual/v13/javascript-interop/llm.txt): Focused latest ReScript v13 pre-release JavaScript interop reference
 - [v12 current LLMs index](https://rescript-lang.org/llms/manual/v12/llms.txt): The LLM file list for the current ReScript v12 documentation
 - [v12 current complete documentation](https://rescript-lang.org/llms/manual/v12/llm-full.txt): The complete current ReScript v12 documentation
-- [v12 current abridged documentation](https://rescript-lang.org/llms/manual/v12/llm-small.txt): A minimal current ReScript v12 reference`
+- [v12 current abridged documentation](https://rescript-lang.org/llms/manual/v12/llm-small.txt): A minimal current ReScript v12 reference
+- [v12 current language overview](https://rescript-lang.org/llms/manual/v12/language-overview/llm.txt): Focused current ReScript v12 language overview
+- [v12 current JavaScript interop](https://rescript-lang.org/llms/manual/v12/javascript-interop/llm.txt): Focused current ReScript v12 JavaScript interop reference`
 
 let manualDocsDirectory = "markdown-pages/docs/manual"
 let reactDocsDirectory = "markdown-pages/docs/react"
@@ -273,6 +420,7 @@ generateFile(
   ~txtFilePath="public/llms.txt",
   ~staleTxtFilePath="public/llms/manual/llms.txt",
   ~staleVersions=["v10", "v11"],
+  ~sectionFiles=manualSectionLlmFiles,
   manualDocsDirectory,
   manualLlmsDirectory,
 )


### PR DESCRIPTION
## Context

The generated LLM indexes were getting noisy with broad/version-specific entries. This PR adds focused manual slices so LLM clients can fetch smaller topic-specific docs, while keeping the root, manual, and React LLM entry points concise.

## Summary

- Generate focused manual section files:
  - `/llms/manual/language-overview/llm.txt`
  - `/llms/manual/javascript-interop/llm.txt`
  - `/llms/manual/build-system/llm.txt`
  - `/llms/manual/getting-started/llm.txt`
- Reference the focused manual files from the generated LLM indexes.
- Remove current/default explanatory wording from generated LLM file lists and human-readable LLM pages.
- Stop generating version-specific manual and React LLM text outputs, and clean stale versioned output directories.
- Stabilize the navigation e2e helper by waiting on nav containers, targeting links by selector/text, and scrolling links into view before clicking.
- Add generator coverage for focused section files, stale version cleanup, reduced index links, and simplified wording.

## Review follow-up

- Addresses the review comments about versioned manual/React `llms.txt` indexes by dropping versioned LLM output generation instead of maintaining pinned version index files.

## Validation

Local:

- `yarn build:res`
- `yarn build:scripts`
- `node --test apps/docs/scripts/__tests__/generate-llms.test.mjs`
- `yarn build:generate-llms`
- `node scripts/test-hrefs.mjs`
- `yarn ci:format`
- `git diff --check`
- `yarn workspace @rescript-lang/docs cypress run --browser electron --config baseUrl=https://codex-llm-manual-sections.rescript-lang.pages.dev,retries=0`

GitHub checks on `965c6e9e`:

- `Format`
- `Site_Checks`
- `Vitest`
- `Visual_Regression`
- `Deploy`
- `E2E Tests`