### PR TITLE
[codex] enable DocSearch insights

### DIFF
--- a/apps/docs/__tests__/Search_.test.res
+++ b/apps/docs/__tests__/Search_.test.res
@@ -486,3 +486,29 @@ test("renders disabled search copy when Algolia config is missing", async () => 
   await element(await screen->getByText("Search unavailable"))->toBeVisible
   await element(await screen->getByLabelText("Search unavailable for this build"))->toBeVisible
 })
+
+test("active DocSearch enables Algolia Insights", async () => {
+  await viewport(1440, 500)
+
+  let _screen = await render(
+    <ReactRouter.MemoryRouter initialEntries=["/"]>
+      <Search.ActiveDocSearch
+        apiKey="test-api-key"
+        appId="TESTAPP"
+        indexName="test_index"
+        deactivateSearch={() => ()}
+        onClose={() => ()}
+      />
+    </ReactRouter.MemoryRouter>,
+  )
+
+  let hasInsightsScript = switch WebAPI.Document.querySelector(
+    document,
+    "script[src*='search-insights']",
+  ) {
+  | Value(_) => true
+  | Null => false
+  }
+
+  expect(hasInsightsScript)->toBe(true)
+})

--- a/apps/docs/src/bindings/DocSearch.res
+++ b/apps/docs/src/bindings/DocSearch.res
@@ -80,6 +80,7 @@ external make: (
   ~hitComponent: hitComponent => React.element=?,
   ~navigator: navigator=?,
   ~onClose: unit => unit=?,
+  ~insights: bool=?,
   ~searchParameters: searchParameters=?,
   ~initialScrollY: int=?,
 ) => React.element = "DocSearchModal"

--- a/apps/docs/src/components/Search.res
+++ b/apps/docs/src/components/Search.res
@@ -324,6 +324,7 @@ module ActiveDocSearch = {
             transformItems={items => normalizeHitUrls(items, ~siteUrl=Env.root_url)}
             hitComponent
             onClose
+            insights=true
             initialScrollY={window.scrollY->Float.toInt}
             searchParameters={
               distinct: 3,


### PR DESCRIPTION
## Context

Algolia's recommended DocSearch path for tracking search result interactions is to enable the built-in Insights integration on the DocSearch modal. The project already depends on `search-insights`, but the modal binding did not expose or pass the `insights` prop.

## Changes

- Add the optional `insights` prop to the ReScript `DocSearchModal` binding.
- Pass `insights=true` from the active search modal.
- Add a browser regression test that renders the active DocSearch modal and verifies the Insights loader is registered.

## Validation

- `yarn build:res`
- `env VITE_ALGOLIA_APP_ID= VITE_ALGOLIA_INDEX_NAME= VITE_ALGOLIA_SEARCH_API_KEY= ../../node_modules/.bin/vitest __tests__/Search_.test.jsx --run --browser.headless`

The Algolia env vars are blanked for the Search browser suite so the existing disabled-search test remains deterministic in a workspace with `.env.local` search credentials.